### PR TITLE
feat(cli): make code the primary worktree command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Git Vibe Flow is a lightweight Git workflow for teams that ship from `main`, kee
 
 The command surface is intentionally small:
 
-- `git vibe start <name>`
+- `git vibe code <name>`
 - `git vibe finish <name>`
 - `git vibe list`
 - `git vibe status`
@@ -69,6 +69,7 @@ The installer:
   - `vibe.branchPrefix=feat/`
   - `vibe.worktreeRoot=../.vibe`
 - appends `~/.git-vibe/bin` to your shell profile if it is not already managed by Git Vibe Flow
+- installs shell integration so `git vibe code ...` moves you into the new worktree and `git vibe finish ...` brings you back to the main worktree after cleanup
 
 If you want the standalone `git-vibe` binary on your shell `PATH`, the installer adds this line to your shell profile:
 
@@ -76,13 +77,21 @@ If you want the standalone `git-vibe` binary on your shell `PATH`, the installer
 export PATH="$HOME/.git-vibe/bin:$PATH"
 ```
 
-Because installers run in a child shell, they cannot modify the `PATH` of the terminal session that launched them. `git vibe ...` works immediately through the Git alias, but a fresh terminal or `source ~/.zshrc` is still needed before `git-vibe` works as a direct shell command.
+Because installers run in a child shell, they cannot modify the current terminal session that launched them. `git vibe ...` works immediately through the Git alias, but a fresh terminal or `source ~/.zshrc` is still needed before direct `git-vibe` usage and the auto-jump shell integration are available in that shell.
 
 Then verify the install:
 
 ```bash
 git vibe version
 ```
+
+After your shell profile is loaded, this should also work the way you expect:
+
+```bash
+git vibe code fallback-app-urls
+```
+
+You will land inside the worktree automatically, and if the VS Code `code` CLI is installed Git Vibe Flow will also open that worktree in VS Code. In a VS Code terminal it replaces the current window so Source Control follows the feature worktree instead of staying on the base repo.
 
 ## Workflow
 
@@ -91,7 +100,7 @@ Start a vibe from a clean `main` checkout:
 ```bash
 git switch main
 git pull --ff-only origin main
-git vibe start fallback-app-urls
+git vibe code fallback-app-urls
 ```
 
 That creates:
@@ -100,6 +109,8 @@ That creates:
 - worktree: `../.vibe/<repo>/fallback-app-urls`
 
 Do all work inside that worktree. Even fixes and urgent patches still live under `feat/*`.
+
+If you rerun `git vibe code fallback-app-urls`, Git Vibe Flow reopens the existing worktree instead of creating a duplicate branch.
 
 When the feature is merged locally:
 
@@ -122,15 +133,17 @@ git vibe finish --sync fallback-app-urls
 
 ## Commands
 
-### `git vibe start <name>`
+### `git vibe code <name>`
 
-Creates a `feat/<slug>` branch from `main` as a new worktree.
+Creates or reopens a `feat/<slug>` worktree. If the vibe does not exist yet, Git Vibe Flow creates the branch from `main` and opens it. If it already exists, Git Vibe Flow jumps back into that same worktree instead of creating a duplicate.
 
 Example:
 
 ```bash
-git vibe start add-billing-webhook
+git vibe code add-billing-webhook
 ```
+
+If the VS Code `code` CLI is available, `git vibe code ...` opens that worktree in VS Code too.
 
 ### `git vibe finish [--local] [--sync] [name]`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when working in a repository that follows Git Vibe F
 
 Use this skill when the user wants to:
 
-- start or finish work with `git vibe`
+- open or finish work with `git vibe`
 - apply a `main` plus `feat/*` workflow
 - isolate tasks with worktrees
 - coordinate parallel human and AI work safely
@@ -33,10 +33,10 @@ Git Vibe Flow is optimized for AI orchestration and parallel work. The point is 
 
 ## Commands
 
-Start a vibe:
+Open a vibe:
 
 ```bash
-git vibe start <name>
+git vibe code <name>
 ```
 
 Finish a vibe after a remote merge:
@@ -132,3 +132,4 @@ The installer does two important things:
 
 - sets a global Git alias so `git vibe ...` works immediately
 - appends `~/.git-vibe/bin` to the shell profile so `git-vibe ...` works in future terminals
+- installs shell integration so `git vibe code ...` and `git vibe finish ...` can move between worktrees automatically

--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -19,6 +19,10 @@ say() {
   printf '%s\n' "$*"
 }
 
+say_shell_chdir() {
+  printf '__GIT_VIBE_CHDIR__=%s\n' "$1"
+}
+
 require_repo() {
   git rev-parse --show-toplevel >/dev/null 2>&1 || die "run this command inside a Git repository"
 }
@@ -226,7 +230,7 @@ print_help() {
 Git Vibe Flow
 
 Usage:
-  git vibe start <name>
+  git vibe code <name>
   git vibe finish [--local] [--sync] [name]
   git vibe list
   git vibe status
@@ -236,73 +240,159 @@ Usage:
   git vibe hook <pre-commit|commit-msg|pre-push> [args...]
 
 Examples:
-  git vibe start fallback-app-urls
+  git vibe code fallback-app-urls
   git vibe finish --sync fallback-app-urls
   git vibe finish --local fallback-app-urls
 EOF
 }
 
-command_start() {
-  local name slug branch base path
-  require_repo
+open_editor_for_path() {
+  local path
+  path="$1"
 
-  [[ $# -gt 0 ]] || die "start requires a feature name"
-
-  name="$*"
-  slug="$(slug_from_name "${name}")"
-  branch="$(branch_from_slug "${slug}")"
-  base="$(base_branch)"
-  path="$(worktree_path_for_slug "${slug}")"
-
-  [[ "$(current_branch)" == "${base}" ]] || die "start from ${base}, not $(current_branch)"
-  ensure_clean_tree "$(repo_root)"
-  branch_exists "${base}" || die "base branch ${base} does not exist locally"
-
-  if branch_exists "${branch}" || remote_branch_exists "origin/${branch}"; then
-    die "branch ${branch} already exists"
+  if ! command -v code >/dev/null 2>&1; then
+    say "Editor: skipped (VS Code CLI 'code' not found)"
+    return 0
   fi
 
-  if [[ -e "${path}" ]]; then
-    die "worktree path already exists: ${path}"
+  if [[ "${TERM_PROGRAM:-}" == "vscode" ]]; then
+    code -r "${path}" >/dev/null 2>&1 || code "${path}" >/dev/null 2>&1 || true
+    say "Editor: opened in VS Code"
+    return 0
   fi
 
-  mkdir -p "$(vibe_root)"
-  git worktree add -b "${branch}" "${path}" "${base}"
-
-  say "Started ${branch}"
-  say "Path: ${path}"
+  code "${path}" >/dev/null 2>&1 || true
+  say "Editor: opened in VS Code"
 }
 
-command_finish() {
-  local name branch slug path mode sync base merged_into
+command_code() {
+  local name slug branch base path shell_output open_editor action base_path
+  local -a name_parts
   require_repo
 
-  mode="auto"
-  sync="false"
-  name=""
+  shell_output="false"
+  open_editor="true"
+  name_parts=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --local)
-        mode="local"
-        shift
+      --shell-output)
+        shell_output="true"
         ;;
-      --sync)
-        sync="true"
-        shift
+      --no-editor)
+        open_editor="false"
         ;;
       -h|--help)
         print_help
         exit 0
         ;;
       *)
-        name="$1"
-        shift
+        name_parts+=("$1")
         ;;
     esac
+    shift
+  done
+
+  [[ ${#name_parts[@]} -gt 0 ]] || die "code requires a feature name"
+
+  name="${name_parts[*]}"
+  slug="$(slug_from_name "${name}")"
+  branch="$(branch_from_slug "${slug}")"
+  base="$(base_branch)"
+  path="$(worktree_path_for_slug "${slug}")"
+  action="Opened"
+
+  if find_worktree_for_branch "${branch}" >/dev/null 2>&1; then
+    path="$(find_worktree_for_branch "${branch}")"
+  elif branch_exists "${branch}"; then
+    if [[ -e "${path}" ]]; then
+      die "worktree path already exists: ${path}"
+    fi
+    mkdir -p "$(vibe_root)"
+    git worktree add "${path}" "${branch}"
+    action="Attached"
+  elif remote_branch_exists "origin/${branch}"; then
+    if [[ -e "${path}" ]]; then
+      die "worktree path already exists: ${path}"
+    fi
+    mkdir -p "$(vibe_root)"
+    git worktree add -b "${branch}" "${path}" "origin/${branch}"
+    git -C "${path}" branch --set-upstream-to "origin/${branch}" "${branch}" >/dev/null 2>&1 || true
+    action="Checked out"
+  else
+    branch_exists "${base}" || die "base branch ${base} does not exist locally"
+    base_path="$(base_worktree_path || true)"
+
+    if [[ -n "${base_path}" ]]; then
+      ensure_clean_tree "${base_path}"
+      git -C "${base_path}" switch "${base}" >/dev/null 2>&1 || true
+    fi
+
+    if [[ -e "${path}" ]]; then
+      die "worktree path already exists: ${path}"
+    fi
+
+    mkdir -p "$(vibe_root)"
+    git worktree add -b "${branch}" "${path}" "${base}"
+    action="Started"
+  fi
+
+  say "${action} ${branch}"
+  say "Path: ${path}"
+
+  if [[ "${open_editor}" == "true" ]]; then
+    open_editor_for_path "${path}"
+  fi
+
+  if [[ "${shell_output}" == "true" ]]; then
+    say_shell_chdir "${path}"
+  fi
+}
+
+command_start() {
+  command_code --no-editor "$@"
+}
+
+command_finish() {
+  local name branch slug path mode sync base merged_into shell_output base_path
+  local -a name_parts
+  require_repo
+
+  mode="auto"
+  sync="false"
+  shell_output="false"
+  name=""
+  name_parts=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --local)
+        mode="local"
+        ;;
+      --sync)
+        sync="true"
+        ;;
+      --shell-output)
+        shell_output="true"
+        ;;
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      *)
+        name_parts+=("$1")
+        ;;
+    esac
+    shift
   done
 
   base="$(base_branch)"
+  base_path="$(base_worktree_path || true)"
+  [[ -n "${base_path}" ]] || base_path="$(repo_root)"
+
+  if [[ ${#name_parts[@]} -gt 0 ]]; then
+    name="${name_parts[*]}"
+  fi
 
   if [[ -z "${name}" ]]; then
     branch="$(current_branch)"
@@ -333,9 +423,10 @@ command_finish() {
     merged_into="${base}"
   elif remote_branch_exists "origin/${base}" && is_ancestor_of "${branch}" "origin/${base}"; then
     sync_base_branch
+    base_path="$(base_worktree_path || true)"
+    [[ -n "${base_path}" ]] || base_path="$(repo_root)"
     merged_into="origin/${base}"
   elif [[ "${mode}" == "local" ]]; then
-    local base_path
     base_path="$(base_worktree_path || true)"
     [[ -n "${base_path}" ]] || die "could not find a worktree for ${base}"
     ensure_clean_tree "${base_path}"
@@ -355,6 +446,10 @@ command_finish() {
 
   say "Finished ${branch}"
   say "Merged into: ${merged_into}"
+
+  if [[ "${shell_output}" == "true" ]]; then
+    say_shell_chdir "${base_path}"
+  fi
 }
 
 command_list() {
@@ -437,7 +532,7 @@ hook_pre_commit() {
   allow="$(git config --bool --get vibe.allowCommitOnBase 2>/dev/null || true)"
 
   if [[ "${current}" == "${base}" && "${VIBE_ALLOW_COMMIT_BASE:-0}" != "1" && "${allow}" != "true" ]]; then
-    die "commits on ${base} are blocked; start a vibe with: git vibe start <name>"
+    die "commits on ${base} are blocked; open a vibe with: git vibe code <name>"
   fi
 }
 
@@ -492,6 +587,10 @@ main() {
   case "${command}" in
     help|-h|--help)
       print_help
+      ;;
+    code)
+      shift
+      command_code "$@"
       ;;
     start)
       shift

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,31 @@ download() {
   curl -fsSL "${RAW_BASE}/${remote_path}" -o "${target}"
 }
 
+shell_integration_block() {
+  cat <<EOF
+${PATH_MARKER_BEGIN}
+${PATH_LINE}
+
+git() {
+  if [ "\$1" = "vibe" ] && { [ "\$2" = "code" ] || [ "\$2" = "start" ] || [ "\$2" = "finish" ]; }; then
+    __git_vibe_output="\$(command git "\$@" --shell-output 2>&1)"
+    __git_vibe_status=\$?
+    __git_vibe_path="\$(printf '%s\n' "\$__git_vibe_output" | sed -n 's/^__GIT_VIBE_CHDIR__=//p' | tail -n 1)"
+    printf '%s\n' "\$__git_vibe_output" | sed '/^__GIT_VIBE_CHDIR__=/d'
+
+    if [ "\$__git_vibe_status" -eq 0 ] && [ -n "\$__git_vibe_path" ]; then
+      builtin cd "\$__git_vibe_path" || return "\$__git_vibe_status"
+    fi
+
+    return "\$__git_vibe_status"
+  fi
+
+  command git "\$@"
+}
+${PATH_MARKER_END}
+EOF
+}
+
 detect_profile() {
   local shell_name
   shell_name="$(basename "${SHELL:-}")"
@@ -41,21 +66,21 @@ detect_profile() {
   esac
 }
 
-ensure_path_in_profile() {
-  local profile
+ensure_shell_integration() {
+  local profile temp
   profile="$(detect_profile)"
   touch "${profile}"
+  temp="$(mktemp)"
 
-  if grep -Fq "${PATH_MARKER_BEGIN}" "${profile}"; then
-    printf '%s\n' "${profile}"
-    return 0
-  fi
+  awk -v begin="${PATH_MARKER_BEGIN}" -v end="${PATH_MARKER_END}" '
+    $0 == begin { skipping = 1; next }
+    $0 == end { skipping = 0; next }
+    !skipping { print }
+  ' "${profile}" > "${temp}"
 
-  {
-    printf '\n%s\n' "${PATH_MARKER_BEGIN}"
-    printf '%s\n' "${PATH_LINE}"
-    printf '%s\n' "${PATH_MARKER_END}"
-  } >> "${profile}"
+  printf '\n' >> "${temp}"
+  shell_integration_block >> "${temp}"
+  mv "${temp}" "${profile}"
 
   printf '%s\n' "${profile}"
 }
@@ -86,7 +111,7 @@ git config --global vibe.branchPrefix feat/
 git config --global vibe.worktreeRoot ../.vibe
 git config --global alias.vibe "!${BIN_DIR}/git-vibe"
 
-PROFILE_FILE="$(ensure_path_in_profile)"
+PROFILE_FILE="$(ensure_shell_integration)"
 
 cat <<EOF
 Git Vibe Flow $(<"${INSTALL_DIR}/VERSION") installed to ${INSTALL_DIR}
@@ -106,9 +131,10 @@ Shell profile updated:
   ${PROFILE_FILE}
 
 Current terminal note:
-  The installer cannot change the PATH of the shell that launched it.
+  The installer cannot change the current shell session that launched it.
   Open a new terminal, run: source "${PROFILE_FILE}", or run:
   ${PATH_LINE}
+  After the profile is loaded, git vibe code/finish will auto-jump between worktrees.
 
 After reloading your shell, run:
   git vibe version

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -5,6 +5,12 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 REPO_DIR="${TMP_DIR}/demo"
 WORKTREE_DIR="${TMP_DIR}/.vibe/demo/smoke-test"
+INSTALL_HOME="${TMP_DIR}/home"
+INSTALL_DIR="${TMP_DIR}/.git-vibe"
+SHELL_REPO_DIR="${TMP_DIR}/shell-demo"
+SHELL_WORKTREE_DIR="${TMP_DIR}/.vibe/shell-demo/shell-jump"
+EXPECTED_SHELL_REPO_DIR=""
+EXPECTED_SHELL_WORKTREE_DIR=""
 
 cleanup() {
   rm -rf "${TMP_DIR}"
@@ -31,7 +37,7 @@ git -C "${REPO_DIR}" config vibe.worktreeRoot ../.vibe
 
 (
   cd "${REPO_DIR}" >/dev/null
-  "${ROOT}/bin/git-vibe" start smoke-test >/dev/null
+  "${ROOT}/bin/git-vibe" code smoke-test >/dev/null
 )
 [[ -d "${WORKTREE_DIR}" ]] || fail "worktree was not created"
 
@@ -50,3 +56,42 @@ if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/smoke-test; th
 fi
 
 printf 'smoke: ok\n'
+
+mkdir -p "${INSTALL_HOME}"
+
+HOME="${INSTALL_HOME}" SHELL=/bin/bash GIT_VIBE_HOME="${INSTALL_DIR}" bash "${ROOT}/install.sh" >/dev/null
+
+git init "${SHELL_REPO_DIR}" >/dev/null
+git -C "${SHELL_REPO_DIR}" config user.name "Git Vibe Smoke"
+git -C "${SHELL_REPO_DIR}" config user.email "smoke@example.com"
+git -C "${SHELL_REPO_DIR}" switch -c main >/dev/null
+
+printf '# Shell Demo\n' > "${SHELL_REPO_DIR}/README.md"
+git -C "${SHELL_REPO_DIR}" add README.md
+VIBE_ALLOW_COMMIT_BASE=1 git -C "${SHELL_REPO_DIR}" commit -m "chore: initial commit" >/dev/null
+git -C "${SHELL_REPO_DIR}" config vibe.baseBranch main
+git -C "${SHELL_REPO_DIR}" config vibe.branchPrefix feat/
+git -C "${SHELL_REPO_DIR}" config vibe.worktreeRoot ../.vibe
+EXPECTED_SHELL_REPO_DIR="$(cd "${SHELL_REPO_DIR}" && pwd -P)"
+
+AUTO_CD_OUTPUT="$(HOME="${INSTALL_HOME}" SHELL=/bin/bash bash -lc '
+  source ~/.bashrc
+  cd "'"${SHELL_REPO_DIR}"'"
+  git vibe code shell-jump >/dev/null
+  pwd -P
+')"
+
+EXPECTED_SHELL_WORKTREE_DIR="$(cd "${SHELL_WORKTREE_DIR}" && pwd -P)"
+
+[[ "${AUTO_CD_OUTPUT}" == "${EXPECTED_SHELL_WORKTREE_DIR}" ]] || fail "shell integration did not move into the new worktree"
+
+FINISH_OUTPUT="$(HOME="${INSTALL_HOME}" SHELL=/bin/bash bash -lc '
+  source ~/.bashrc
+  cd "'"${SHELL_REPO_DIR}"'"
+  git vibe finish --local shell-jump >/dev/null
+  pwd -P
+')"
+
+[[ "${FINISH_OUTPUT}" == "${EXPECTED_SHELL_REPO_DIR}" ]] || fail "shell integration did not return to the base worktree after finish"
+
+printf 'smoke: shell integration ok\n'


### PR DESCRIPTION
## Summary

- make `git vibe code <name>` the primary way to create or reopen a vibe worktree
- auto-jump between worktrees through shell integration and open the worktree in VS Code when the `code` CLI is available
- update docs and smoke tests for the code-first workflow

## Testing

- bash ./tests/smoke.sh