### PR TITLE
fix(cli): finish branch cleanup from base worktree

### DIFF
--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -437,12 +437,18 @@ command_finish() {
 
   [[ -n "${merged_into}" ]] || die "branch ${branch} is not merged into ${base}; merge it first or use --local"
 
-  if [[ -d "${path}" ]]; then
-    git worktree remove "${path}"
-  fi
+  [[ -n "${base_path}" ]] || die "could not find a stable worktree for ${base}"
 
-  git branch -d "${branch}" >/dev/null
-  git worktree prune >/dev/null 2>&1 || true
+  (
+    cd "${base_path}" >/dev/null 2>&1 || die "could not enter ${base_path}"
+
+    if [[ -d "${path}" ]]; then
+      git worktree remove "${path}"
+    fi
+
+    git branch -d "${branch}" >/dev/null
+    git worktree prune >/dev/null 2>&1 || true
+  )
 
   say "Finished ${branch}"
   say "Merged into: ${merged_into}"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 REPO_DIR="${TMP_DIR}/demo"
 WORKTREE_DIR="${TMP_DIR}/.vibe/demo/smoke-test"
+WORKTREE_FINISH_DIR="${TMP_DIR}/.vibe/demo/worktree-finish"
 INSTALL_HOME="${TMP_DIR}/home"
 INSTALL_DIR="${TMP_DIR}/.git-vibe"
 SHELL_REPO_DIR="${TMP_DIR}/shell-demo"
@@ -56,6 +57,28 @@ if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/smoke-test; th
 fi
 
 printf 'smoke: ok\n'
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" code worktree-finish >/dev/null
+)
+[[ -d "${WORKTREE_FINISH_DIR}" ]] || fail "worktree finish path was not created"
+
+printf '\nWorktree finish change\n' >> "${WORKTREE_FINISH_DIR}/README.md"
+git -C "${WORKTREE_FINISH_DIR}" add README.md
+git -C "${WORKTREE_FINISH_DIR}" commit -m "feat: update readme from worktree" >/dev/null
+
+(
+  cd "${WORKTREE_FINISH_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" finish --local >/dev/null
+)
+
+[[ ! -d "${WORKTREE_FINISH_DIR}" ]] || fail "worktree still exists after finishing from inside the vibe"
+if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/worktree-finish; then
+  fail "feature branch still exists after finishing from inside the vibe"
+fi
+
+printf 'smoke: worktree finish ok\n'
 
 mkdir -p "${INSTALL_HOME}"
 


### PR DESCRIPTION
## Summary

- run finish cleanup from the base worktree instead of the vibe being removed
- prevent branch deletion from failing when finish is run inside the feature worktree
- add smoke coverage for finishing a vibe from inside its own worktree

## Testing

- bash ./tests/smoke.sh