### PR TITLE
feat(cli): add release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The command surface is intentionally small:
 
 - `git vibe code <name>`
 - `git vibe finish <name>`
+- `git vibe release <version>`
 - `git vibe list`
 - `git vibe status`
 - `git vibe prune`
@@ -26,10 +27,10 @@ This is a better fit for fast-moving teams and AI-assisted development, where mu
 
 Git Vibe Flow is also built for AI orchestration. When every `feat/*` branch gets its own worktree by default, you can safely run multiple agents, terminals, test runs, and experiments side by side without branch hopping, stash juggling, or cross-task contamination.
 
-## What v0.0.1 includes
+## What the workflow includes
 
 - A portable `git-vibe` executable exposed as `git vibe ...`
-- `start`, `finish`, `list`, `status`, `path`, `prune`, and `version` commands
+- `code`, `finish`, `release`, `list`, `status`, `path`, `prune`, and `version` commands
 - Global hook wrappers for `pre-commit`, `commit-msg`, and `pre-push`
 - Semantic commit enforcement
 - Base-branch protection against direct commits and pushes
@@ -155,6 +156,31 @@ Finishes a vibe safely.
 
 Run it with no name from inside a feature worktree to finish the current vibe.
 
+### `git vibe release <version>`
+
+Cuts a release directly from `main`. Git Vibe Flow updates the plain-text `VERSION` file, creates a `chore(release): vX.Y.Z` commit on `main`, and adds an annotated `vX.Y.Z` tag.
+
+Example:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git vibe release 0.0.2
+```
+
+The command is intentionally narrow:
+
+- it must be run from `main`
+- the working tree must be clean
+- it expects a plain-text version file at `VERSION`
+- it creates the commit and tag locally
+
+After that, push the release explicitly:
+
+```bash
+VIBE_ALLOW_PUSH_BASE=1 git push origin main --tags
+```
+
 ### `git vibe list`
 
 Lists active feature worktrees for the current repository.
@@ -229,6 +255,14 @@ Useful repo-level override example:
 git config vibe.worktreeRoot ../worktrees
 ```
 
+Release command example:
+
+```bash
+git config vibe.releaseVersionFile VERSION
+```
+
+`git vibe release` expects that file to be a plain-text file containing only the version string.
+
 ## Release and tagging
 
 There is no `develop` branch in Git Vibe Flow. Releases are cut directly from `main`.
@@ -238,24 +272,19 @@ The release flow is:
 1. make sure every feature for the release is already merged into `main`
 2. switch to `main`
 3. fast-forward to the remote
-4. bump the version
-5. create a release commit on `main`
-6. create an annotated tag
-7. push `main` and the tag
+4. run `git vibe release <version>`
+5. push `main` and the tag
 
-For Git Vibe Flow `0.0.1`, the commands are:
+For Git Vibe Flow `0.0.2`, the commands are:
 
 ```bash
 git switch main
 git pull --ff-only origin main
-printf '0.0.1\n' > VERSION
-git add VERSION
-VIBE_ALLOW_COMMIT_BASE=1 git commit -m "chore(release): v0.0.1"
-git tag -a v0.0.1 -m "v0.0.1"
+git vibe release 0.0.2
 VIBE_ALLOW_PUSH_BASE=1 git push origin main --tags
 ```
 
-The key point is simple: without `develop`, the tag is created on the release commit that lives on `main`.
+Under the hood, `git vibe release 0.0.2` writes `0.0.2` to `VERSION`, commits `chore(release): v0.0.2`, and creates the annotated tag `v0.0.2` on `main`.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -51,6 +51,12 @@ Finish a vibe with a local fast-forward merge:
 git vibe finish --local <name>
 ```
 
+Cut a release directly from `main`:
+
+```bash
+git vibe release <version>
+```
+
 List active vibes:
 
 ```bash
@@ -105,14 +111,11 @@ VIBE_ALLOW_PUSH_BASE=1 git push origin main
 ```bash
 git switch main
 git pull --ff-only origin main
-printf '0.0.1\n' > VERSION
-git add VERSION
-VIBE_ALLOW_COMMIT_BASE=1 git commit -m "chore(release): v0.0.1"
-git tag -a v0.0.1 -m "v0.0.1"
+git vibe release 0.0.2
 VIBE_ALLOW_PUSH_BASE=1 git push origin main --tags
 ```
 
-The tag always points at the release commit on `main`.
+The release command updates the plain-text `VERSION` file, creates `chore(release): vX.Y.Z` on `main`, and adds the annotated `vX.Y.Z` tag.
 
 ## Install
 

--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -51,6 +51,12 @@ branch_prefix() {
   printf '%s\n' "${configured:-feat/}"
 }
 
+release_version_file() {
+  local configured
+  configured="$(git_config_get vibe.releaseVersionFile)"
+  printf '%s\n' "${configured:-VERSION}"
+}
+
 worktree_root_setting() {
   local configured
   configured="$(git_config_get vibe.worktreeRoot)"
@@ -123,6 +129,10 @@ ensure_clean_tree() {
 
 branch_exists() {
   git show-ref --verify --quiet "refs/heads/$1"
+}
+
+tag_exists() {
+  git show-ref --verify --quiet "refs/tags/$1"
 }
 
 remote_branch_exists() {
@@ -225,6 +235,17 @@ run_fetch() {
   git fetch origin "${base}"
 }
 
+normalize_release_version() {
+  local normalized
+  normalized="${1#v}"
+
+  if [[ ! "${normalized}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    die "release version must look like 0.0.2 or v0.0.2"
+  fi
+
+  printf '%s\n' "${normalized}"
+}
+
 print_help() {
   cat <<'EOF'
 Git Vibe Flow
@@ -232,6 +253,7 @@ Git Vibe Flow
 Usage:
   git vibe code <name>
   git vibe finish [--local] [--sync] [name]
+  git vibe release <version>
   git vibe list
   git vibe status
   git vibe path <name>
@@ -243,6 +265,7 @@ Examples:
   git vibe code fallback-app-urls
   git vibe finish --sync fallback-app-urls
   git vibe finish --local fallback-app-urls
+  git vibe release 0.0.2
 EOF
 }
 
@@ -458,6 +481,44 @@ command_finish() {
   fi
 }
 
+command_release() {
+  local raw_version version tag base version_file version_path
+  require_repo
+
+  [[ $# -gt 0 ]] || die "release requires a version"
+  [[ $# -eq 1 ]] || die "release accepts exactly one version"
+
+  base="$(base_branch)"
+  [[ "$(current_branch)" == "${base}" ]] || die "release must be run from ${base}"
+
+  ensure_clean_tree "$(repo_root)"
+
+  raw_version="$1"
+  version="$(normalize_release_version "${raw_version}")"
+  tag="v${version}"
+  version_file="$(release_version_file)"
+  version_path="$(repo_root)/${version_file}"
+
+  [[ -f "${version_path}" ]] || die "release version file not found: ${version_file}"
+  tag_exists "${tag}" && die "tag ${tag} already exists"
+
+  if [[ "$(<"${version_path}")" == "${version}" ]]; then
+    die "release version ${version} is already recorded in ${version_file}"
+  fi
+
+  printf '%s\n' "${version}" > "${version_path}"
+
+  git add "${version_file}"
+  VIBE_ALLOW_COMMIT_BASE=1 git commit -m "chore(release): ${tag}" >/dev/null
+  git tag -a "${tag}" -m "${tag}"
+
+  say "Released ${tag}"
+  say "Version file: ${version_file}"
+  say ""
+  say "Next:"
+  say "  VIBE_ALLOW_PUSH_BASE=1 git push origin ${base} --tags"
+}
+
 command_list() {
   require_repo
 
@@ -605,6 +666,10 @@ main() {
     finish)
       shift
       command_finish "$@"
+      ;;
+    release)
+      shift
+      command_release "$@"
       ;;
     list)
       shift

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -80,6 +80,21 @@ fi
 
 printf 'smoke: worktree finish ok\n'
 
+printf '0.0.0\n' > "${REPO_DIR}/VERSION"
+git -C "${REPO_DIR}" add VERSION
+VIBE_ALLOW_COMMIT_BASE=1 git -C "${REPO_DIR}" commit -m "chore: add version file" >/dev/null
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" release 0.1.0 >/dev/null
+)
+
+[[ "$(<"${REPO_DIR}/VERSION")" == "0.1.0" ]] || fail "release did not update VERSION"
+[[ "$(git -C "${REPO_DIR}" log -1 --pretty=%s)" == "chore(release): v0.1.0" ]] || fail "release did not create the expected commit"
+[[ "$(git -C "${REPO_DIR}" tag --list "v0.1.0")" == "v0.1.0" ]] || fail "release did not create the expected tag"
+
+printf 'smoke: release ok\n'
+
 mkdir -p "${INSTALL_HOME}"
 
 HOME="${INSTALL_HOME}" SHELL=/bin/bash GIT_VIBE_HOME="${INSTALL_DIR}" bash "${ROOT}/install.sh" >/dev/null


### PR DESCRIPTION
## Summary

- add `git vibe release <version>` for cutting releases directly from `main`
- update the README and skill docs for the new maintainer release flow
- add smoke coverage for the release commit and tag behavior

## Testing

- bash ./tests/smoke.sh