### PR TITLE
feat(cli): add release push flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The command surface is intentionally small:
 - `git vibe code <name>`
 - `git vibe finish <name>`
 - `git vibe release <version>`
+- `git vibe release <version> --push`
 - `git vibe list`
 - `git vibe status`
 - `git vibe prune`
@@ -164,7 +165,7 @@ Finishes a vibe safely.
 
 Run it with no name from inside a feature worktree to finish the current vibe.
 
-### `git vibe release <version>`
+### `git vibe release <version> [--push]`
 
 Cuts a release directly from `main`. Git Vibe Flow updates the plain-text `VERSION` file, creates a `chore(release): vX.Y.Z` commit on `main`, and adds an annotated `vX.Y.Z` tag.
 
@@ -183,11 +184,13 @@ The command is intentionally narrow:
 - it expects a plain-text version file at `VERSION`
 - it creates the commit and tag locally
 
-After that, push the release explicitly:
+If you want Git Vibe Flow to push the release for you, use:
 
 ```bash
-VIBE_ALLOW_PUSH_BASE=1 git push origin main --tags
+git vibe release 0.0.2 --push
 ```
+
+That uses the maintainer override internally, so it still works even in repos that explicitly block raw `main` pushes.
 
 ### `git vibe list`
 
@@ -237,9 +240,15 @@ Accepted examples:
 
 ### `pre-push`
 
-Blocks direct pushes from the base branch by default.
+Allows pushes from the base branch by default.
 
-Override when you intentionally need to push `main`:
+If a repo wants Git Vibe Flow to block raw `main` pushes again, opt into that explicitly:
+
+```bash
+git config vibe.disallowPushOnBase true
+```
+
+Then the escape hatch is still:
 
 ```bash
 VIBE_ALLOW_PUSH_BASE=1 git push origin main
@@ -263,6 +272,12 @@ Useful repo-level override example:
 git config vibe.worktreeRoot ../worktrees
 ```
 
+To block raw `main` pushes in a specific repo:
+
+```bash
+git config vibe.disallowPushOnBase true
+```
+
 Release command example:
 
 ```bash
@@ -280,7 +295,7 @@ The release flow is:
 1. make sure every feature for the release is already merged into `main`
 2. switch to `main`
 3. fast-forward to the remote
-4. run `git vibe release <version>`
+4. run `git vibe release <version>` or `git vibe release <version> --push`
 5. push `main` and the tag
 
 For Git Vibe Flow `0.0.2`, the commands are:
@@ -288,11 +303,10 @@ For Git Vibe Flow `0.0.2`, the commands are:
 ```bash
 git switch main
 git pull --ff-only origin main
-git vibe release 0.0.2
-VIBE_ALLOW_PUSH_BASE=1 git push origin main --tags
+git vibe release 0.0.2 --push
 ```
 
-Under the hood, `git vibe release 0.0.2` writes `0.0.2` to `VERSION`, commits `chore(release): v0.0.2`, and creates the annotated tag `v0.0.2` on `main`.
+Under the hood, `git vibe release 0.0.2 --push` writes `0.0.2` to `VERSION`, commits `chore(release): v0.0.2`, creates the annotated tag `v0.0.2` on `main`, and pushes both `main` and the tag to `origin`.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -63,6 +63,12 @@ Cut a release directly from `main`:
 git vibe release <version>
 ```
 
+Cut and push a release directly from `main`:
+
+```bash
+git vibe release <version> --push
+```
+
 List active vibes:
 
 ```bash
@@ -102,14 +108,20 @@ git vibe version
 ## Hook behavior and overrides
 
 - Direct commits on `main` are blocked by default.
-- Direct pushes on `main` are blocked by default.
+- Direct pushes on `main` are allowed by default.
 - Semantic commit messages are enforced by the global hooks.
 
-Use these overrides only for deliberate maintainer actions such as release commits:
+Use these overrides only for deliberate maintainer actions such as release commits or for repos that explicitly block raw `main` pushes:
 
 ```bash
 VIBE_ALLOW_COMMIT_BASE=1 git commit -m "chore(release): v0.0.1"
 VIBE_ALLOW_PUSH_BASE=1 git push origin main
+```
+
+If a repo wants Git Vibe Flow to block raw `main` pushes again, set:
+
+```bash
+git config vibe.disallowPushOnBase true
 ```
 
 ## Release flow
@@ -117,11 +129,10 @@ VIBE_ALLOW_PUSH_BASE=1 git push origin main
 ```bash
 git switch main
 git pull --ff-only origin main
-git vibe release 0.0.2
-VIBE_ALLOW_PUSH_BASE=1 git push origin main --tags
+git vibe release 0.0.2 --push
 ```
 
-The release command updates the plain-text `VERSION` file, creates `chore(release): vX.Y.Z` on `main`, and adds the annotated `vX.Y.Z` tag.
+The release command updates the plain-text `VERSION` file, creates `chore(release): vX.Y.Z` on `main`, adds the annotated `vX.Y.Z` tag, and can push `main` plus the tag to `origin` when you pass `--push`.
 
 ## Finish modes
 

--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -135,6 +135,24 @@ tag_exists() {
   git show-ref --verify --quiet "refs/tags/$1"
 }
 
+push_blocked_on_base() {
+  local disallow allow
+  disallow="$(git config --bool --get vibe.disallowPushOnBase 2>/dev/null || true)"
+  if [[ "${disallow}" == "true" ]]; then
+    printf '%s\n' "true"
+    return 0
+  fi
+
+  # Backward compatibility for older installs that used allowPushOnBase.
+  allow="$(git config --bool --get vibe.allowPushOnBase 2>/dev/null || true)"
+  if [[ "${allow}" == "false" ]]; then
+    printf '%s\n' "true"
+    return 0
+  fi
+
+  printf '%s\n' "false"
+}
+
 remote_branch_exists() {
   git show-ref --verify --quiet "refs/remotes/$1"
 }
@@ -235,6 +253,14 @@ run_fetch() {
   git fetch origin "${base}"
 }
 
+push_base_branch_and_tags() {
+  local base
+  base="$1"
+
+  git remote get-url origin >/dev/null 2>&1 || die "origin remote is not configured"
+  VIBE_ALLOW_PUSH_BASE=1 git push origin "${base}" --tags
+}
+
 normalize_release_version() {
   local normalized
   normalized="${1#v}"
@@ -253,7 +279,7 @@ Git Vibe Flow
 Usage:
   git vibe code <name>
   git vibe finish [--local] [--sync] [name]
-  git vibe release <version>
+  git vibe release <version> [--push]
   git vibe list
   git vibe status
   git vibe path <name>
@@ -267,6 +293,7 @@ Examples:
   git vibe finish --sync fallback-app-urls
   git vibe finish --local fallback-app-urls
   git vibe release 0.0.2
+  git vibe release 0.0.2 --push
 EOF
 }
 
@@ -483,18 +510,39 @@ command_finish() {
 }
 
 command_release() {
-  local raw_version version tag base version_file version_path
+  local raw_version version tag base version_file version_path push_after_release
   require_repo
 
-  [[ $# -gt 0 ]] || die "release requires a version"
-  [[ $# -eq 1 ]] || die "release accepts exactly one version"
+  raw_version=""
+  push_after_release="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --push)
+        push_after_release="true"
+        ;;
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      --*)
+        die "unknown flag for release: $1"
+        ;;
+      *)
+        [[ -z "${raw_version}" ]] || die "release accepts exactly one version"
+        raw_version="$1"
+        ;;
+    esac
+    shift
+  done
+
+  [[ -n "${raw_version}" ]] || die "release requires a version"
 
   base="$(base_branch)"
   [[ "$(current_branch)" == "${base}" ]] || die "release must be run from ${base}"
 
   ensure_clean_tree "$(repo_root)"
 
-  raw_version="$1"
   version="$(normalize_release_version "${raw_version}")"
   tag="v${version}"
   version_file="$(release_version_file)"
@@ -513,11 +561,21 @@ command_release() {
   VIBE_ALLOW_COMMIT_BASE=1 git commit -m "chore(release): ${tag}" >/dev/null
   git tag -a "${tag}" -m "${tag}"
 
+  if [[ "${push_after_release}" == "true" ]]; then
+    push_base_branch_and_tags "${base}"
+  fi
+
   say "Released ${tag}"
   say "Version file: ${version_file}"
-  say ""
-  say "Next:"
-  say "  VIBE_ALLOW_PUSH_BASE=1 git push origin ${base} --tags"
+
+  if [[ "${push_after_release}" == "true" ]]; then
+    say "Pushed: origin/${base} and ${tag}"
+  else
+    say ""
+    say "Next:"
+    say "  git vibe release ${version} --push"
+    say "  or: git push origin ${base} --tags"
+  fi
 }
 
 command_list() {
@@ -610,14 +668,14 @@ hook_commit_msg() {
 }
 
 hook_pre_push() {
-  local base current allow
+  local base current blocked
   require_repo
 
   base="$(base_branch)"
   current="$(current_branch)"
-  allow="$(git config --bool --get vibe.allowPushOnBase 2>/dev/null || true)"
+  blocked="$(push_blocked_on_base)"
 
-  if [[ "${current}" == "${base}" && "${VIBE_ALLOW_PUSH_BASE:-0}" != "1" && "${allow}" != "true" ]]; then
+  if [[ "${current}" == "${base}" && "${VIBE_ALLOW_PUSH_BASE:-0}" != "1" && "${blocked}" == "true" ]]; then
     die "pushes from ${base} are blocked; merge via PR or override with VIBE_ALLOW_PUSH_BASE=1"
   fi
 }

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 REPO_DIR="${TMP_DIR}/demo"
+ORIGIN_DIR="${TMP_DIR}/origin.git"
+HOOKS_DIR="${TMP_DIR}/hooks"
 WORKTREE_DIR="${TMP_DIR}/.vibe/demo/smoke-test"
 WORKTREE_FINISH_DIR="${TMP_DIR}/.vibe/demo/worktree-finish"
 INSTALL_HOME="${TMP_DIR}/home"
@@ -24,17 +26,31 @@ fail() {
   exit 1
 }
 
+mkdir -p "${HOOKS_DIR}"
+for hook in pre-commit commit-msg pre-push; do
+  cat > "${HOOKS_DIR}/${hook}" <<EOF
+#!/usr/bin/env bash
+exec "${ROOT}/bin/git-vibe" hook ${hook} "\$@"
+EOF
+  chmod +x "${HOOKS_DIR}/${hook}"
+done
+
 git init "${REPO_DIR}" >/dev/null
 git -C "${REPO_DIR}" config user.name "Git Vibe Smoke"
 git -C "${REPO_DIR}" config user.email "smoke@example.com"
+git -C "${REPO_DIR}" config core.hooksPath "${HOOKS_DIR}"
 git -C "${REPO_DIR}" switch -c main >/dev/null
+git init --bare "${ORIGIN_DIR}" >/dev/null
 
 printf '# Demo\n' > "${REPO_DIR}/README.md"
 git -C "${REPO_DIR}" add README.md
 VIBE_ALLOW_COMMIT_BASE=1 git -C "${REPO_DIR}" commit -m "chore: initial commit" >/dev/null
+git -C "${REPO_DIR}" remote add origin "${ORIGIN_DIR}"
 git -C "${REPO_DIR}" config vibe.baseBranch main
 git -C "${REPO_DIR}" config vibe.branchPrefix feat/
 git -C "${REPO_DIR}" config vibe.worktreeRoot ../.vibe
+git -C "${REPO_DIR}" config vibe.disallowPushOnBase false
+git -C "${REPO_DIR}" push -u origin main >/dev/null
 
 (
   cd "${REPO_DIR}" >/dev/null
@@ -86,12 +102,14 @@ VIBE_ALLOW_COMMIT_BASE=1 git -C "${REPO_DIR}" commit -m "chore: add version file
 
 (
   cd "${REPO_DIR}" >/dev/null
-  "${ROOT}/bin/git-vibe" release 0.1.0 >/dev/null
+  "${ROOT}/bin/git-vibe" release 0.1.0 --push >/dev/null
 )
 
 [[ "$(<"${REPO_DIR}/VERSION")" == "0.1.0" ]] || fail "release did not update VERSION"
 [[ "$(git -C "${REPO_DIR}" log -1 --pretty=%s)" == "chore(release): v0.1.0" ]] || fail "release did not create the expected commit"
 [[ "$(git -C "${REPO_DIR}" tag --list "v0.1.0")" == "v0.1.0" ]] || fail "release did not create the expected tag"
+git --git-dir="${ORIGIN_DIR}" show-ref --verify --quiet refs/tags/v0.1.0 || fail "release --push did not push the tag"
+[[ "$(git -C "${REPO_DIR}" rev-parse HEAD)" == "$(git --git-dir="${ORIGIN_DIR}" rev-parse refs/heads/main)" ]] || fail "release --push did not push main"
 
 printf 'smoke: release ok\n'
 


### PR DESCRIPTION
## Summary

- add `git vibe release <version> --push` so releases can tag and push in one command
- allow raw pushes from `main` by default, with an opt-in `vibe.disallowPushOnBase=true` block for repos that want it
- update the docs, skill, and smoke test coverage for the new release and base-push behavior

## Testing

- bash ./tests/smoke.sh