### PR TITLE
fix(release): make version file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Classic `git-flow` assumes a world with long-lived `develop` branches, release b
 - Every work branch starts as `feat/<slug>`, including fixes and urgent patches.
 - Every `feat/*` branch is created as its own worktree.
 - `main` stays clean and deployable.
-- Releases are cut directly from `main` with a version bump commit and a tag.
+- Releases are cut directly from `main` with a release commit and a tag.
 
 This is a better fit for fast-moving teams and AI-assisted development, where multiple experiments can happen in parallel and isolation matters more than branch hierarchy.
 
@@ -175,7 +175,7 @@ Run it with no name from inside a feature worktree to finish the current vibe.
 
 ### `git vibe release <version> [--push]`
 
-Cuts a release directly from `main`. Git Vibe updates the plain-text `VERSION` file, creates a `chore(release): vX.Y.Z` commit on `main`, and adds an annotated `vX.Y.Z` tag.
+Cuts a release directly from `main`. Git Vibe creates a `chore(release): vX.Y.Z` commit on `main` and adds an annotated `vX.Y.Z` tag. If the repo already has a top-level `VERSION` file, or you configure `vibe.releaseVersionFile`, Git Vibe updates that plain-text file too.
 
 Example:
 
@@ -189,8 +189,8 @@ The command is intentionally narrow:
 
 - it must be run from `main`
 - the working tree must be clean
-- it expects a plain-text version file at `VERSION`
 - it creates the commit and tag locally
+- it only auto-updates plain-text version files
 
 If you want Git Vibe to push the release for you, use:
 
@@ -292,7 +292,7 @@ Release command example:
 git config vibe.releaseVersionFile VERSION
 ```
 
-`git vibe release` expects that file to be a plain-text file containing only the version string.
+`git vibe release` only auto-manages plain-text version files containing the version string by itself. If your project keeps its version in `package.json` or somewhere else, bump that file yourself before cutting the release. Without this config, Git Vibe auto-updates a top-level `VERSION` file when one already exists and otherwise skips version-file changes.
 
 ## Release and tagging
 
@@ -314,7 +314,7 @@ git pull --ff-only origin main
 git vibe release 0.0.2 --push
 ```
 
-Under the hood, `git vibe release 0.0.2 --push` writes `0.0.2` to `VERSION`, commits `chore(release): v0.0.2`, creates the annotated tag `v0.0.2` on `main`, and pushes both `main` and the tag to `origin`.
+Under the hood, `git vibe release 0.0.2 --push` creates `chore(release): v0.0.2`, creates the annotated tag `v0.0.2` on `main`, and pushes both `main` and the tag to `origin`. If Git Vibe is managing a plain-text version file for that repo, it writes `0.0.2` there first.
 
 ## Development
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@ Classic `git-flow` was built for a different world. Git Vibe Flow is for teams t
 - `finish` can clean up after a remote PR merge or perform a local fast-forward merge
 - global hooks protect `main` from direct commits and pushes
 - semantic commit messages are enforced
-- releases are cut directly from `main` with a version bump commit and an annotated tag
+- releases are cut directly from `main` with a release commit and an annotated tag
 
 ## Included in 0.0.1
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -144,7 +144,7 @@ git pull --ff-only origin main
 git vibe release 0.0.2 --push
 ```
 
-The release command updates the plain-text `VERSION` file, creates `chore(release): vX.Y.Z` on `main`, adds the annotated `vX.Y.Z` tag, and can push `main` plus the tag to `origin` when you pass `--push`.
+The release command creates `chore(release): vX.Y.Z` on `main`, adds the annotated `vX.Y.Z` tag, and can push `main` plus the tag to `origin` when you pass `--push`. If the repo already has a top-level `VERSION` file, or you configure `vibe.releaseVersionFile`, Git Vibe updates that plain-text file too.
 
 ## Finish modes
 

--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -52,9 +52,17 @@ branch_prefix() {
 }
 
 release_version_file() {
-  local configured
+  local configured root
   configured="$(git_config_get vibe.releaseVersionFile)"
-  printf '%s\n' "${configured:-VERSION}"
+  if [[ -n "${configured}" ]]; then
+    printf '%s\n' "${configured}"
+    return 0
+  fi
+
+  root="$(repo_root)"
+  if [[ -f "${root}/VERSION" ]]; then
+    printf '%s\n' "VERSION"
+  fi
 }
 
 worktree_root_setting() {
@@ -510,11 +518,12 @@ command_finish() {
 }
 
 command_release() {
-  local raw_version version tag base version_file version_path push_after_release
+  local raw_version version tag base version_file version_path push_after_release version_file_status
   require_repo
 
   raw_version=""
   push_after_release="false"
+  version_file_status="none"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -546,19 +555,22 @@ command_release() {
   version="$(normalize_release_version "${raw_version}")"
   tag="v${version}"
   version_file="$(release_version_file)"
-  version_path="$(repo_root)/${version_file}"
-
-  [[ -f "${version_path}" ]] || die "release version file not found: ${version_file}"
   tag_exists "${tag}" && die "tag ${tag} already exists"
 
-  if [[ "$(<"${version_path}")" == "${version}" ]]; then
-    die "release version ${version} is already recorded in ${version_file}"
+  if [[ -n "${version_file}" ]]; then
+    version_path="$(repo_root)/${version_file}"
+    [[ -f "${version_path}" ]] || die "release version file not found: ${version_file}"
+
+    if [[ "$(<"${version_path}")" == "${version}" ]]; then
+      version_file_status="unchanged"
+    else
+      printf '%s\n' "${version}" > "${version_path}"
+      git add "${version_file}"
+      version_file_status="updated"
+    fi
   fi
 
-  printf '%s\n' "${version}" > "${version_path}"
-
-  git add "${version_file}"
-  VIBE_ALLOW_COMMIT_BASE=1 git commit -m "chore(release): ${tag}" >/dev/null
+  VIBE_ALLOW_COMMIT_BASE=1 git commit --allow-empty -m "chore(release): ${tag}" >/dev/null
   git tag -a "${tag}" -m "${tag}"
 
   if [[ "${push_after_release}" == "true" ]]; then
@@ -566,7 +578,17 @@ command_release() {
   fi
 
   say "Released ${tag}"
-  say "Version file: ${version_file}"
+  case "${version_file_status}" in
+    updated)
+      say "Updated version file: ${version_file}"
+      ;;
+    unchanged)
+      say "Version file already matched: ${version_file}"
+      ;;
+    *)
+      say "Version file: skipped"
+      ;;
+  esac
 
   if [[ "${push_after_release}" == "true" ]]; then
     say "Pushed: origin/${base} and ${tag}"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -96,22 +96,35 @@ fi
 
 printf 'smoke: worktree finish ok\n'
 
-printf '0.0.0\n' > "${REPO_DIR}/VERSION"
-git -C "${REPO_DIR}" add VERSION
-VIBE_ALLOW_COMMIT_BASE=1 git -C "${REPO_DIR}" commit -m "chore: add version file" >/dev/null
-
 (
   cd "${REPO_DIR}" >/dev/null
   "${ROOT}/bin/git-vibe" release 0.1.0 --push >/dev/null
 )
 
-[[ "$(<"${REPO_DIR}/VERSION")" == "0.1.0" ]] || fail "release did not update VERSION"
 [[ "$(git -C "${REPO_DIR}" log -1 --pretty=%s)" == "chore(release): v0.1.0" ]] || fail "release did not create the expected commit"
 [[ "$(git -C "${REPO_DIR}" tag --list "v0.1.0")" == "v0.1.0" ]] || fail "release did not create the expected tag"
+[[ ! -f "${REPO_DIR}/VERSION" ]] || fail "release unexpectedly created VERSION"
 git --git-dir="${ORIGIN_DIR}" show-ref --verify --quiet refs/tags/v0.1.0 || fail "release --push did not push the tag"
 [[ "$(git -C "${REPO_DIR}" rev-parse HEAD)" == "$(git --git-dir="${ORIGIN_DIR}" rev-parse refs/heads/main)" ]] || fail "release --push did not push main"
 
 printf 'smoke: release ok\n'
+
+printf '0.1.0\n' > "${REPO_DIR}/VERSION"
+git -C "${REPO_DIR}" add VERSION
+VIBE_ALLOW_COMMIT_BASE=1 git -C "${REPO_DIR}" commit -m "chore: add version file" >/dev/null
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" release 0.2.0 --push >/dev/null
+)
+
+[[ "$(<"${REPO_DIR}/VERSION")" == "0.2.0" ]] || fail "release did not update VERSION"
+[[ "$(git -C "${REPO_DIR}" log -1 --pretty=%s)" == "chore(release): v0.2.0" ]] || fail "release did not create the expected commit with VERSION present"
+[[ "$(git -C "${REPO_DIR}" tag --list "v0.2.0")" == "v0.2.0" ]] || fail "release did not create the expected tag with VERSION present"
+git --git-dir="${ORIGIN_DIR}" show-ref --verify --quiet refs/tags/v0.2.0 || fail "release --push did not push the second tag"
+[[ "$(git -C "${REPO_DIR}" rev-parse HEAD)" == "$(git --git-dir="${ORIGIN_DIR}" rev-parse refs/heads/main)" ]] || fail "release --push did not push main after updating VERSION"
+
+printf 'smoke: release with version file ok\n'
 
 mkdir -p "${INSTALL_HOME}"
 


### PR DESCRIPTION
## Summary
- allow `git vibe release` to work without requiring a managed `VERSION` file
- keep plain-text version file updates when `VERSION` exists or `vibe.releaseVersionFile` is configured
- update smoke coverage and docs for both release paths

## Testing
- bash tests/smoke.sh