### PR TITLE
feat(cli): add configurable editor launch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The installer:
 - appends `~/.git-vibe/bin` to your shell profile if it is not already managed by Git Vibe
 - installs shell integration so `git vibe code ...` moves you into the new worktree and `git vibe finish ...` brings you back to the main worktree after cleanup
 
+Editor launch defaults to `auto`, which means Git Vibe opens VS Code only in interactive terminals. You can override that per repo or globally with `vibe.openEditor=auto|always|never`.
+
 If you want the standalone `git-vibe` binary on your shell `PATH`, the installer adds this line to your shell profile:
 
 ```bash
@@ -94,7 +96,7 @@ After your shell profile is loaded, this should also work the way you expect:
 git vibe code fallback-app-urls
 ```
 
-You will land inside the worktree automatically, and if the VS Code `code` CLI is installed Git Vibe will also open that worktree in VS Code. In a VS Code terminal it replaces the current window so Source Control follows the feature worktree instead of staying on the base repo.
+You will land inside the worktree automatically, and in interactive terminals Git Vibe will also open that worktree in VS Code when the `code` CLI is installed. In a VS Code terminal it replaces the current window so Source Control follows the feature worktree instead of staying on the base repo.
 
 If you prefer short aliases, the installer also gives you:
 
@@ -149,7 +151,7 @@ git vibe finish --sync fallback-app-urls
 
 ## Commands
 
-### `git vibe code <name>`
+### `git vibe code [--editor] [--no-editor] <name>`
 
 Creates or reopens a `feat/<slug>` worktree. If the vibe does not exist yet, Git Vibe creates the branch from `main` and opens it. If it already exists, Git Vibe jumps back into that same worktree instead of creating a duplicate.
 
@@ -159,7 +161,13 @@ Example:
 git vibe code add-billing-webhook
 ```
 
-If the VS Code `code` CLI is available, `git vibe code ...` opens that worktree in VS Code too.
+Editor launch follows `vibe.openEditor`, which accepts `auto`, `always`, or `never`.
+
+- `auto` is the default and opens VS Code only in interactive terminals
+- `always` opens VS Code whenever the `code` CLI is available
+- `never` skips editor launch
+
+Use `--editor` or `--no-editor` to override the config for a single run.
 
 ### `git vibe finish [--local] [--sync] [name]`
 
@@ -278,6 +286,13 @@ Useful repo-level override example:
 
 ```bash
 git config vibe.worktreeRoot ../worktrees
+```
+
+Editor launch policy:
+
+```bash
+git config --global vibe.openEditor auto
+git config vibe.openEditor never
 ```
 
 To block raw `main` pushes in a specific repo:

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,6 +39,8 @@ Open a vibe:
 git vibe code <name>
 ```
 
+Editor launch follows `vibe.openEditor=auto|always|never`. The default is `auto`, which opens VS Code only in interactive terminals. Use `--editor` or `--no-editor` to override that for one run.
+
 Open a vibe with the short alias:
 
 ```bash

--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -51,6 +51,40 @@ branch_prefix() {
   printf '%s\n' "${configured:-feat/}"
 }
 
+open_editor_mode() {
+  local configured
+  configured="$(git_config_get vibe.openEditor)"
+  printf '%s\n' "${configured:-auto}"
+}
+
+validate_open_editor_mode() {
+  case "$1" in
+    auto|always|never)
+      ;;
+    *)
+      die "invalid vibe.openEditor: $1 (expected auto, always, or never)"
+      ;;
+  esac
+}
+
+should_open_editor() {
+  local mode
+  mode="$1"
+  validate_open_editor_mode "${mode}"
+
+  case "${mode}" in
+    always)
+      return 0
+      ;;
+    never)
+      return 1
+      ;;
+    auto)
+      [[ -t 0 && -t 1 ]]
+      ;;
+  esac
+}
+
 release_version_file() {
   local configured root
   configured="$(git_config_get vibe.releaseVersionFile)"
@@ -285,7 +319,7 @@ print_help() {
 Git Vibe
 
 Usage:
-  git vibe code <name>
+  git vibe code [--editor|--no-editor] <name>
   git vibe finish [--local] [--sync] [name]
   git vibe release <version> [--push]
   git vibe list
@@ -297,6 +331,7 @@ Usage:
 
 Examples:
   git vibe code fallback-app-urls
+  git vibe code --no-editor fallback-app-urls
   git vibe finish fallback-app-urls
   git vibe finish --sync fallback-app-urls
   git vibe finish --local fallback-app-urls
@@ -325,12 +360,12 @@ open_editor_for_path() {
 }
 
 command_code() {
-  local name slug branch base path shell_output open_editor action base_path
+  local name slug branch base path shell_output open_editor action base_path editor_mode
   local -a name_parts
   require_repo
 
   shell_output="false"
-  open_editor="true"
+  open_editor=""
   name_parts=()
 
   while [[ $# -gt 0 ]]; do
@@ -338,8 +373,11 @@ command_code() {
       --shell-output)
         shell_output="true"
         ;;
+      --editor)
+        open_editor="always"
+        ;;
       --no-editor)
-        open_editor="false"
+        open_editor="never"
         ;;
       -h|--help)
         print_help
@@ -399,7 +437,12 @@ command_code() {
   say "${action} ${branch}"
   say "Path: ${path}"
 
-  if [[ "${open_editor}" == "true" ]]; then
+  editor_mode="$(open_editor_mode)"
+  if [[ -n "${open_editor}" ]]; then
+    editor_mode="${open_editor}"
+  fi
+
+  if should_open_editor "${editor_mode}"; then
     open_editor_for_path "${path}"
   fi
 
@@ -615,19 +658,22 @@ command_list() {
 }
 
 command_status() {
-  local base current prefix root
+  local base current prefix root editor_mode
   require_repo
 
   base="$(base_branch)"
   current="$(current_branch)"
   prefix="$(branch_prefix)"
   root="$(vibe_root)"
+  editor_mode="$(open_editor_mode)"
+  validate_open_editor_mode "${editor_mode}"
 
   say "Repo: $(repo_root)"
   say "Base branch: ${base}"
   say "Current branch: ${current}"
   say "Branch prefix: ${prefix}"
   say "Vibe root: ${root}"
+  say "Open editor: ${editor_mode}"
   say ""
   command_list
 }

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -8,10 +8,16 @@ ORIGIN_DIR="${TMP_DIR}/origin.git"
 HOOKS_DIR="${TMP_DIR}/hooks"
 WORKTREE_DIR="${TMP_DIR}/.vibe/demo/smoke-test"
 WORKTREE_FINISH_DIR="${TMP_DIR}/.vibe/demo/worktree-finish"
+AUTO_EDITOR_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/auto-editor"
+ALWAYS_EDITOR_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/always-editor"
+NEVER_EDITOR_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/never-editor"
+FORCED_EDITOR_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/forced-editor"
 INSTALL_HOME="${TMP_DIR}/home"
 INSTALL_DIR="${TMP_DIR}/.git-vibe"
 SHELL_REPO_DIR="${TMP_DIR}/shell-demo"
 SHELL_WORKTREE_DIR="${TMP_DIR}/.vibe/shell-demo/shell-jump"
+FAKE_BIN_DIR="${TMP_DIR}/fake-bin"
+CODE_LOG="${TMP_DIR}/code.log"
 EXPECTED_SHELL_REPO_DIR=""
 EXPECTED_SHELL_WORKTREE_DIR=""
 
@@ -25,6 +31,13 @@ fail() {
   printf 'smoke: %s\n' "$*" >&2
   exit 1
 }
+
+mkdir -p "${FAKE_BIN_DIR}"
+cat > "${FAKE_BIN_DIR}/code" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${CODE_LOG}"
+EOF
+chmod +x "${FAKE_BIN_DIR}/code"
 
 mkdir -p "${HOOKS_DIR}"
 for hook in pre-commit commit-msg pre-push; do
@@ -95,6 +108,60 @@ if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/worktree-finis
 fi
 
 printf 'smoke: worktree finish ok\n'
+
+git -C "${REPO_DIR}" config vibe.openEditor auto
+: > "${CODE_LOG}"
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" code auto-editor >/dev/null
+)
+
+[[ -d "${AUTO_EDITOR_WORKTREE_DIR}" ]] || fail "auto editor worktree was not created"
+[[ ! -s "${CODE_LOG}" ]] || fail "auto editor mode should skip editor launch in non-interactive runs"
+git -C "${REPO_DIR}" worktree remove "${AUTO_EDITOR_WORKTREE_DIR}" >/dev/null
+git -C "${REPO_DIR}" branch -d feat/auto-editor >/dev/null
+
+git -C "${REPO_DIR}" config vibe.openEditor always
+: > "${CODE_LOG}"
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" code always-editor >/dev/null
+)
+
+[[ -d "${ALWAYS_EDITOR_WORKTREE_DIR}" ]] || fail "always editor worktree was not created"
+[[ -s "${CODE_LOG}" ]] || fail "always editor mode should launch the editor"
+git -C "${REPO_DIR}" worktree remove "${ALWAYS_EDITOR_WORKTREE_DIR}" >/dev/null
+git -C "${REPO_DIR}" branch -d feat/always-editor >/dev/null
+
+git -C "${REPO_DIR}" config vibe.openEditor never
+: > "${CODE_LOG}"
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" code never-editor >/dev/null
+)
+
+[[ -d "${NEVER_EDITOR_WORKTREE_DIR}" ]] || fail "never editor worktree was not created"
+[[ ! -s "${CODE_LOG}" ]] || fail "never editor mode should skip editor launch"
+git -C "${REPO_DIR}" worktree remove "${NEVER_EDITOR_WORKTREE_DIR}" >/dev/null
+git -C "${REPO_DIR}" branch -d feat/never-editor >/dev/null
+
+: > "${CODE_LOG}"
+
+(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" code --editor forced-editor >/dev/null
+)
+
+[[ -d "${FORCED_EDITOR_WORKTREE_DIR}" ]] || fail "forced editor worktree was not created"
+[[ -s "${CODE_LOG}" ]] || fail "--editor should override vibe.openEditor=never"
+git -C "${REPO_DIR}" worktree remove "${FORCED_EDITOR_WORKTREE_DIR}" >/dev/null
+git -C "${REPO_DIR}" branch -d feat/forced-editor >/dev/null
+git -C "${REPO_DIR}" config --unset vibe.openEditor
+
+printf 'smoke: editor modes ok\n'
 
 (
   cd "${REPO_DIR}" >/dev/null


### PR DESCRIPTION
## Summary
- add `vibe.openEditor=auto|always|never` with `auto` as the default
- add `--editor` and keep `--no-editor` as one-shot overrides for `git vibe code`
- document the behavior in the README and skill doc, and cover the modes in smoke tests

## Testing
- bash tests/smoke.sh