### PR TITLE
feat(config): add vibe.mode for solo and worktree workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Git Vibe
 
-Git Vibe is a lightweight Git workflow for teams that ship from `main`, keep all work on `feat/*` branches, and treat every `feat/*` branch as a worktree from the moment it is created.
+Git Vibe is a lightweight Git workflow for teams that ship from `main`, keep all work on `feat/*` branches, and want a worktree-first flow for parallel lanes without giving up a simpler solo mode for single-checkout work.
 
 The command surface is intentionally small:
 
@@ -23,7 +23,7 @@ The command surface is intentionally small:
 - `git vibe doctor [--repair]`
 - `git vibe prune`
 
-Under the hood, every vibe is a short-lived `feat/*` branch that is created as its own worktree. That gives humans and AI agents isolated lanes to work in without polluting `main`.
+Under the hood, every vibe is a short-lived `feat/*` branch. In the default `worktree` mode, Git Vibe opens that branch in its own worktree so humans and AI agents can work in isolated lanes without polluting `main`. In `solo` mode, Git Vibe creates or switches the branch in your current checkout instead.
 
 ## Why Git Vibe
 
@@ -31,13 +31,14 @@ Classic `git-flow` assumes a world with long-lived `develop` branches, release b
 
 - `main` is the only long-lived branch.
 - Every work branch starts as `feat/<slug>`, including fixes and urgent patches.
-- Every `feat/*` branch is created as its own worktree.
+- `worktree` mode gives each `feat/*` branch its own worktree.
+- `solo` mode keeps the `feat/*` branch in your current checkout.
 - `main` stays clean and deployable.
 - Releases are cut directly from `main` with a release commit and a tag.
 
 This is a better fit for fast-moving teams and AI-assisted development, where multiple experiments can happen in parallel and isolation matters more than branch hierarchy.
 
-Git Vibe is also built for AI orchestration. When every `feat/*` branch gets its own worktree by default, you can safely run multiple agents, terminals, test runs, and experiments side by side without branch hopping, stash juggling, or cross-task contamination.
+Git Vibe is also built for AI orchestration. When `worktree` mode is active, you can safely run multiple agents, terminals, test runs, and experiments side by side without branch hopping, stash juggling, or cross-task contamination. When you are working solo and mostly want `git switch`, `npm run dev`, and UI iteration in one checkout, `solo` mode keeps the workflow lighter.
 
 ## What the workflow includes
 
@@ -46,8 +47,8 @@ Git Vibe is also built for AI orchestration. When every `feat/*` branch gets its
 - Global hook wrappers for `pre-commit`, `commit-msg`, and `pre-push`
 - Semantic commit enforcement
 - Base-branch protection against direct commits and pushes
-- Default worktree layout under `../.vibe/<repo>/<slug>`
-- A simple workflow for human and AI parallel work without `develop`, `fix/*`, or `release/*` branches
+- Default worktree layout under `../.vibe/<repo>/<slug>` when `worktree` mode is active
+- A worktree-first workflow for parallel human and AI work, with an opt-in `solo` mode for one-checkout branch work
 
 ## Install
 
@@ -136,6 +137,35 @@ git vibe pr
 git vibe submit
 ```
 
+## Choosing a mode
+
+Git Vibe stays `worktree`-first by default because that is still the safest path for parallel human and AI work.
+
+Use `worktree` when:
+
+- you want one task per isolated directory
+- you are running multiple agents or experiments in parallel
+- you want the editor and shell to jump to a separate lane automatically
+
+Use `solo` when:
+
+- you usually have one active branch at a time
+- you mostly want `git switch`, `npm run dev`, and quick UI iteration
+- you want the editor to stay pointed at the same checkout while the branch changes underneath it
+
+Set your personal default with:
+
+```bash
+git config --global vibe.mode solo
+```
+
+Or keep the global default and override one command at a time:
+
+```bash
+git vibe code --solo polish-pricing-copy
+git vibe code --worktree stabilize-release-flow
+```
+
 ## Workflow
 
 Start a vibe from a clean `main` checkout:
@@ -146,18 +176,20 @@ git pull --ff-only origin main
 git vibe code fallback-app-urls
 ```
 
-That creates:
+In the default `worktree` mode, that creates:
 
 - branch: `feat/fallback-app-urls`
 - worktree: `../.vibe/<repo>/fallback-app-urls`
 
 Do all work inside that worktree. Even fixes and urgent patches still live under `feat/*`.
 
-If you rerun `git vibe code fallback-app-urls`, Git Vibe reopens the existing worktree instead of creating a duplicate branch.
+If you prefer a single-checkout flow, set `vibe.mode=solo`. Then the same command creates or switches to `feat/fallback-app-urls` in your current checkout instead of opening a second path.
+
+If you rerun `git vibe code fallback-app-urls`, Git Vibe reopens the existing vibe instead of creating a duplicate branch. That means reopening the worktree in `worktree` mode, or switching back to the branch in your current checkout in `solo` mode.
 
 If you start from an issue number, Git Vibe fetches the issue title through `gh` and creates a deterministic branch such as `feat/9-issue-aware-vibe-creation`. Later reruns of `git vibe code 9` or `git vibe issue 9` reopen that same vibe even if the issue title changes on GitHub.
 
-When it opens or reopens a vibe, Git Vibe also prints a short workspace summary with the branch, base, path, compare target, and current change state. That makes the worktree feel anchored even in tools that do not visibly switch context for you.
+When it opens or reopens a vibe, Git Vibe also prints a short workspace summary with the branch, base, backing, path, compare target, and current change state. That keeps the lane anchored whether the vibe lives in a separate worktree or in your current checkout.
 
 If you attach session metadata, that summary also carries the session label, task, and last activity timestamp. That gives each vibe a lightweight memory so it is easier to come back later and understand what the lane was for.
 
@@ -217,9 +249,9 @@ git vibe doctor
 
 ## Commands
 
-### `git vibe code [--editor] [--no-editor] [--codex|--vscode] <name|number>`
+### `git vibe code [--solo|--worktree] [--editor] [--no-editor] [--codex|--vscode] <name|number>`
 
-Creates or reopens a `feat/<slug>` worktree. If the vibe does not exist yet, Git Vibe creates the branch from `main` and opens it. If it already exists, Git Vibe jumps back into that same worktree instead of creating a duplicate.
+Creates or reopens a `feat/<slug>` vibe. If the vibe does not exist yet, Git Vibe creates the branch from `main` and opens it using the effective mode. If it already exists, Git Vibe reopens the existing backing instead of creating a duplicate lane.
 
 Example:
 
@@ -239,15 +271,15 @@ Workspace launch follows `vibe.openEditor`, which accepts `auto`, `always`, or `
 - `always` opens your configured workspace app whenever its CLI is available
 - `never` skips workspace launch
 
-Use `--editor` or `--no-editor` to override the launch policy for a single run. Use `--codex` or `--vscode` when you want to force a specific app for that one command.
+Use `--solo` or `--worktree` to override the configured workflow mode for one run. Use `--editor` or `--no-editor` to override the launch policy for a single run. Use `--codex` or `--vscode` when you want to force a specific app for that one command.
 
-After opening a vibe, Git Vibe prints a context summary with the branch, base, path, compare target, and current change state so you can orient yourself quickly in Codex, VS Code, or a plain terminal.
+After opening a vibe, Git Vibe prints a context summary with the branch, base, backing, path, compare target, and current change state so you can orient yourself quickly in Codex, VS Code, or a plain terminal.
 
-Fresh vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that means `node_modules` when the base checkout already has it. You can extend or replace that list with `vibe.sharedPaths` or `[vibe].sharedPaths` in `vibe.toml`.
+Fresh worktree-backed vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that means `node_modules` when the base checkout already has it. You can extend or replace that list with `vibe.sharedPaths` or `[vibe].sharedPaths` in `vibe.toml`.
 
 If you pass `--agent <agent>` or `--task <task>`, Git Vibe also records lightweight session metadata for that vibe.
 
-### `git vibe issue [--editor] [--no-editor] [--codex|--vscode] [--agent <agent>] [--task <task>] <number>`
+### `git vibe issue [--solo|--worktree] [--editor] [--no-editor] [--codex|--vscode] [--agent <agent>] [--task <task>] <number>`
 
 Explicit issue-first alias for `git vibe code <number>`.
 
@@ -277,29 +309,33 @@ Creates a pull request for the current vibe, or for the named vibe when run from
 
 Alias for `git vibe pr`.
 
-### `git vibe enter [name]`
+### `git vibe enter [--editor|--no-editor] [--codex|--vscode] [name]`
 
-Jumps back into an existing vibe worktree and prints the same focused context summary.
+Jumps back into an existing vibe and prints the same focused context summary.
 
 - run it from `main` with a vibe name when you want to reopen a specific lane
 - run it inside a vibe with no name to confirm where you are and re-anchor the current workspace
-- shell integration uses it for an explicit "take me there" flow when `git vibe code ...` was not the command that opened your current terminal
+- in `worktree` mode it jumps back into the separate worktree path
+- in `solo` mode it switches the current checkout back to the vibe branch, keeps the same repo path, and follows the normal editor-launch policy so the same checkout can reopen in your workspace app
+- shell integration uses it for an explicit "take me there" flow whether that means changing directories or only switching branches
+- use `--codex`, `--vscode`, `--editor`, or `--no-editor` when you want to override that behavior for one run
 - if the vibe has saved session metadata, `enter` also shows that context again so resuming the lane feels less guessy
 
 ### `git vibe open [--codex|--vscode] [name]`
 
 Reopens an existing vibe in Codex Desktop or VS Code and prints the same focused context summary.
 
-- run it from `main` with a vibe name when the shell is in one place but you want the app to follow the worktree
+- run it from `main` with a vibe name when the shell is in one place but you want the app to follow the vibe backing
 - run it inside a vibe with no name to reopen the current lane in your workspace app
+- in `solo` mode it switches the branch first, then reopens the same checkout in the workspace app
 - use `--codex` or `--vscode` to force a target app for one run
 
 ### `git vibe diff [name]`
 
 Shows the current vibe's cumulative diff against its base branch.
 
-- run it inside a vibe worktree with no name to inspect the current lane
-- pass a vibe name from `main` when you want to inspect another active worktree
+- run it inside an active vibe with no name to inspect the current lane
+- pass a vibe name from `main` when you want to inspect another vibe, even if that branch is not currently checked out
 - untracked files are called out explicitly so they do not disappear from the mental model
 
 ### `git vibe finish [--local] [--sync] [--delete-remote|--keep-remote] [name]`
@@ -307,14 +343,14 @@ Shows the current vibe's cumulative diff against its base branch.
 Finishes a vibe safely.
 
 - With no flag, `git vibe finish <name>` uses the default auto mode. It checks local `main` and your current `origin/main` refs, then cleans up if the branch is already merged.
-- If the branch is already merged into local `main`, it cleans up the worktree and deletes the branch.
+- If the branch is already merged into local `main`, it cleans up the vibe and deletes the branch.
 - If the branch is merged into `origin/main`, it fast-forwards local `main`, then cleans up.
 - If you pass `--local`, it merges the branch into local `main` with `--ff-only`, then cleans up.
 - If you pass `--sync`, it fetches `origin/main` first, then runs the same cleanup check with fresh remote refs.
 - If you pass `--delete-remote`, Git Vibe also deletes `origin/<branch>` after merge verification and before local cleanup.
 - If you pass `--keep-remote`, it skips remote deletion even when the repo config would normally do it.
 
-Run it with no name from inside a feature worktree to finish the current vibe.
+Run it with no name from inside a feature branch to finish the current vibe. In `solo` mode, Git Vibe switches the current checkout back to `main` before deleting the branch.
 
 Use `finish` when the branch lifecycle is complete. Use `doctor` or `prune` when the branch is still open but the worktree metadata got out of sync.
 
@@ -459,6 +495,7 @@ Example `vibe.toml`:
 
 ```toml
 [vibe]
+mode = "worktree"
 baseBranch = "main"
 branchPrefix = "feat/"
 worktreeRoot = "../.vibe"
@@ -480,6 +517,7 @@ pre-release = "npm test"
 
 Supported `[vibe]` keys:
 
+- `mode`
 - `baseBranch`
 - `branchPrefix`
 - `worktreeRoot`
@@ -504,6 +542,20 @@ git config --global vibe.branchPrefix feat/
 git config --global vibe.worktreeRoot ../.vibe
 ```
 
+Workflow mode:
+
+```bash
+git config --global vibe.mode solo
+git config vibe.mode worktree
+```
+
+Supported values are:
+
+- `worktree` to keep the current Git Vibe behavior, where each vibe gets its own worktree
+- `solo` to create or switch the vibe branch in your current checkout instead
+
+`worktree` remains the built-in default. `worktreeRoot` only matters when the effective mode is `worktree`.
+
 Useful repo-level override example:
 
 ```bash
@@ -525,6 +577,8 @@ git config vibe.openWorkspaceWith codex
 ```
 
 `vibe.openWorkspaceWith=auto` prefers Codex Desktop inside a Codex shell and otherwise uses VS Code when available.
+
+If your usual solo flow is "switch the branch and reopen the same checkout in VS Code," set `vibe.mode=solo` and `vibe.openWorkspaceWith=vscode`.
 
 Issue-driven branch naming:
 
@@ -548,7 +602,7 @@ git config --global vibe.sharedPaths node_modules
 git config vibe.sharedPaths "node_modules,.venv"
 ```
 
-`vibe.sharedPaths` is a comma-separated list of relative repo paths to symlink from the primary checkout into fresh vibes before `post-create` runs. Git Vibe also adds those linked paths to the worktree-local exclude file so the new vibe stays clean.
+`vibe.sharedPaths` is a comma-separated list of relative repo paths to symlink from the primary checkout into fresh worktree-backed vibes before `post-create` runs. Git Vibe also adds those linked paths to the worktree-local exclude file so the new vibe stays clean.
 
 - the built-in default is `node_modules`
 - set it to `none` to disable automatic shared path linking
@@ -590,7 +644,7 @@ versioning = "npm"
 
 Lifecycle hooks live in the `[hooks]` section of `vibe.toml` and run through `sh -c`.
 
-- `post-create` runs after Git Vibe creates, attaches, or checks out a new worktree, after shared path plumbing is linked, and before it prints the final workspace context
+- `post-create` runs after Git Vibe creates, attaches, or checks out a new worktree-backed vibe, after shared path plumbing is linked, and before it prints the final workspace context
 - `pre-finish` runs after merge verification succeeds and before Git Vibe deletes the worktree or branch
 - `pre-release` runs after release validation passes and before Git Vibe updates the version file, commits, or tags
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-vibe
-description: Use this skill when working in a repository that follows Git Vibe, where `main` is the only long-lived branch, all work branches stay under `feat/*`, every `feat/*` branch is created as a worktree, and releases are cut directly from `main` with annotated tags.
+description: Use this skill when working in a repository that follows Git Vibe, where `main` is the only long-lived branch, all work branches stay under `feat/*`, worktree mode is the default, solo mode is available for single-checkout work, and releases are cut directly from `main` with annotated tags.
 ---
 
 # Git Vibe
@@ -10,6 +10,7 @@ Use this skill when the user wants to:
 - open or finish work with `git vibe`
 - apply a `main` plus `feat/*` workflow
 - isolate tasks with worktrees
+- keep branch work in one checkout with solo mode
 - coordinate parallel human and AI work safely
 - inspect active vibes or worktree paths
 - cut a release directly from `main`
@@ -18,7 +19,9 @@ Use this skill when the user wants to:
 
 - `main` is the only long-lived branch.
 - All work branches use `feat/<slug>`, even for bug fixes and urgent patches.
-- Every `feat/*` branch is created as its own worktree.
+- `worktree` is the built-in default mode.
+- `worktree` mode creates each `feat/*` branch as its own worktree.
+- `solo` mode creates or switches the `feat/*` branch in the current checkout.
 - `main` should remain clean and deployable.
 - Releases happen directly on `main` with a release commit and an annotated tag.
 
@@ -31,12 +34,16 @@ Git Vibe is optimized for AI orchestration and parallel work. The point is to ma
 - no stash-heavy branch hopping
 - no mixing unrelated AI-generated diffs in one checkout
 
+When the user is mostly doing one branch at a time, quick UI tweaks, or `npm run dev` loops in a single checkout, prefer `solo` mode. When the user wants parallel human or AI lanes, prefer the default `worktree` mode.
+
 ## Commands
 
 Open a vibe:
 
 ```bash
 git vibe code <name>
+git vibe code --solo <name>
+git vibe code --worktree <name>
 ```
 
 Attach agent session context while you open it:
@@ -61,6 +68,16 @@ git vibe submit
 
 Workspace launch follows `vibe.openEditor=auto|always|never`. The default is `auto`, which opens a workspace app only in interactive terminals. Use `--editor` or `--no-editor` to override that for one run, and `--codex` or `--vscode` to force the target app. After opening a vibe, Git Vibe should print enough branch/base/diff context that the worktree feels anchored even when the editor or terminal does not visibly switch for you. Fresh vibes should also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. The built-in default is `node_modules`, repos can override or extend it with `vibe.sharedPaths`, and linked paths should be added to the worktree-local exclude file so the vibe stays clean.
 
+Git Vibe resolves mode with this precedence:
+
+1. explicit `--solo` or `--worktree` flag on `code`, `issue`, or `start`
+2. local repo Git config `vibe.mode`
+3. repo-root `vibe.toml`
+4. global Git config
+5. built-in default `worktree`
+
+When the effective mode is `solo`, `git vibe code`, `git vibe issue`, and `git vibe start` should create or switch the branch in the current checkout. `git vibe enter` should switch back to that branch in the same checkout and, unless shell-output mode is in use, honor the usual editor-launch policy so the lane can reopen in VS Code or Codex without moving paths. `git vibe open` should switch the branch first and then reopen the same checkout in the configured workspace app.
+
 Issue-driven vibes use `gh issue view` to build deterministic branch names. `vibe.issueBranchStyle=number-and-title|number-only|title-only` controls the naming shape, and Git Vibe remembers the issue-to-branch mapping locally so later issue-title edits do not break reopen flows.
 
 Shared repo defaults should live in a checked-in `vibe.toml`, not only in ad hoc local Git config. The precedence should be:
@@ -71,6 +88,8 @@ Shared repo defaults should live in a checked-in `vibe.toml`, not only in ad hoc
 4. built-in defaults
 
 Keep the `vibe.toml` format intentionally small. Git Vibe only needs straightforward scalar settings under `[vibe]` plus lifecycle commands under `[hooks]`. Use `sharedPaths = "node_modules,.venv"` when a repo wants fresh vibes to reuse base-checkout runtime plumbing.
+
+`vibe.mode = "solo"` is the right recommendation when the user usually has one active branch at a time and wants the editor to stay on the same checkout. `vibe.mode = "worktree"` is the right recommendation when the user is running multiple tasks, agents, or experiments in parallel.
 
 PR-driven handoff uses `gh pr create`, `gh pr view`, and `gh pr checks` so the workflow stays GitHub-native. `git vibe check` should surface PR/check summary when available, and `git vibe checks` should let users inspect the individual checks without leaving the vibe flow.
 
@@ -161,13 +180,15 @@ git vibe list
 
 `git vibe list` should act like a control tower for the repo. It should show active vibe branches, worktree state like `clean`, `dirty`, `locked`, or `prunable`, ahead/behind against the base branch, lightweight session context when present, and a short change summary.
 
+In `solo` mode, `git vibe list` should still show branch-only vibes even when they are not currently checked out. `git vibe path` should return the current checkout path for solo vibes and the worktree path for worktree-backed vibes.
+
 Show vibe status:
 
 ```bash
 git vibe status
 ```
 
-`git vibe status` or `git vibe check` should stay useful both from `main` and from inside a vibe worktree. When run inside a vibe, the reported vibe root should still point at the shared repo-level worktree area, not a nested path under the current worktree. If a vibe has saved session metadata, status should surface the agent label, task, and last activity clearly enough that a human can resume the lane without guessing. It should also show the active shared path plumbing so runtime setup is visible instead of magical.
+`git vibe status` or `git vibe check` should stay useful both from `main` and from inside a vibe checkout. When run inside a worktree-backed vibe, the reported vibe root should still point at the shared repo-level worktree area, not a nested path under the current worktree. If a vibe has saved session metadata, status should surface the agent label, task, last activity, configured mode, and actual backing clearly enough that a human can resume the lane without guessing. It should also show the active shared path plumbing so runtime setup is visible instead of magical.
 
 Show the path for a vibe:
 

--- a/bin/git-vibe
+++ b/bin/git-vibe
@@ -293,6 +293,20 @@ issue_branch_style() {
   printf '%s\n' "${configured:-number-and-title}"
 }
 
+vibe_mode_setting() {
+  local configured
+  configured="$(shared_setting_get vibe.mode vibe mode)"
+  printf '%s\n' "${configured:-worktree}"
+}
+
+resolve_vibe_mode() {
+  local requested resolved
+  requested="${1:-}"
+  resolved="${requested:-$(vibe_mode_setting)}"
+  validate_vibe_mode "${resolved}"
+  printf '%s\n' "${resolved}"
+}
+
 shared_paths_setting() {
   local configured
   configured="$(shared_setting_get vibe.sharedPaths vibe sharedPaths)"
@@ -409,6 +423,16 @@ validate_issue_branch_style() {
       ;;
     *)
       die "invalid vibe.issueBranchStyle: $1 (expected number-and-title, number-only, or title-only)"
+      ;;
+  esac
+}
+
+validate_vibe_mode() {
+  case "$1" in
+    worktree|solo)
+      ;;
+    *)
+      die "invalid vibe.mode: $1 (expected worktree or solo)"
       ;;
   esac
 }
@@ -634,6 +658,12 @@ current_branch() {
   git branch --show-current
 }
 
+current_branch_at_path() {
+  local path
+  path="$1"
+  git -C "${path}" branch --show-current 2>/dev/null || true
+}
+
 slugify() {
   printf '%s' "$*" \
     | tr '[:upper:]' '[:lower:]' \
@@ -697,6 +727,22 @@ issue_url_mapping() {
   git_config_get "$(issue_url_key "$1")"
 }
 
+branch_mode_key() {
+  printf 'vibe.branch.%s.mode\n' "$(slug_from_branch "$1")"
+}
+
+branch_path_key() {
+  printf 'vibe.branch.%s.path\n' "$(slug_from_branch "$1")"
+}
+
+branch_mode_mapping() {
+  git_config_get "$(branch_mode_key "$1")"
+}
+
+branch_path_mapping() {
+  git_config_get "$(branch_path_key "$1")"
+}
+
 remember_issue_branch() {
   local number branch title url
   number="$1"
@@ -707,6 +753,23 @@ remember_issue_branch() {
   git config "$(issue_branch_key "${number}")" "${branch}"
   git config "$(issue_title_key "${number}")" "${title}"
   git config "$(issue_url_key "${number}")" "${url}"
+}
+
+remember_branch_workspace() {
+  local branch mode path
+  branch="$1"
+  mode="$2"
+  path="$3"
+
+  git config "$(branch_mode_key "${branch}")" "${mode}"
+  git config "$(branch_path_key "${branch}")" "${path}"
+}
+
+clear_branch_workspace() {
+  local branch
+  branch="$1"
+  git config --unset-all "$(branch_mode_key "${branch}")" >/dev/null 2>&1 || true
+  git config --unset-all "$(branch_path_key "${branch}")" >/dev/null 2>&1 || true
 }
 
 require_gh() {
@@ -1216,6 +1279,50 @@ find_worktree_for_branch() {
   return 1
 }
 
+vibe_backing_for_branch() {
+  local branch path recorded
+  branch="$1"
+  recorded="$(branch_mode_mapping "${branch}")"
+  if [[ -n "${recorded}" ]]; then
+    validate_vibe_mode "${recorded}"
+    printf '%s\n' "${recorded}"
+    return 0
+  fi
+
+  path="$(find_worktree_for_branch "${branch}" || true)"
+
+  if [[ -n "${path}" ]]; then
+    if [[ "${path}" == "$(primary_repo_root)" ]]; then
+      printf '%s\n' "solo"
+    else
+      printf '%s\n' "worktree"
+    fi
+    return 0
+  fi
+
+  branch_exists "${branch}" || die "vibe branch not found: ${branch}"
+  printf '%s\n' "solo"
+}
+
+vibe_path_for_branch() {
+  local branch path
+  branch="$1"
+  path="$(find_worktree_for_branch "${branch}" || true)"
+
+  if [[ -n "${path}" ]]; then
+    printf '%s\n' "${path}"
+    return 0
+  fi
+
+  path="$(branch_path_mapping "${branch}")"
+  if [[ -n "${path}" ]]; then
+    printf '%s\n' "${path}"
+    return 0
+  fi
+
+  printf '%s\n' "$(primary_repo_root)"
+}
+
 worktree_records_raw() {
   local path branch head detached bare locked prunable locked_reason prunable_reason line
   path=""
@@ -1308,6 +1415,35 @@ list_vibes_raw() {
   done < <(worktree_records_raw)
 }
 
+local_vibe_branches_raw() {
+  local prefix
+  prefix="$(branch_prefix)"
+  git for-each-ref --format='%(refname:short)' "refs/heads/${prefix}*"
+}
+
+worktree_record_for_branch() {
+  local target branch path head detached bare locked locked_reason prunable prunable_reason
+  target="$1"
+
+  while IFS=$'\t' read -r branch path head detached bare locked locked_reason prunable prunable_reason; do
+    if [[ "${branch}" == "${target}" ]]; then
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "${branch}" \
+        "${path}" \
+        "${head}" \
+        "${detached}" \
+        "${bare}" \
+        "${locked}" \
+        "${locked_reason}" \
+        "${prunable}" \
+        "${prunable_reason}"
+      return 0
+    fi
+  done < <(list_vibes_raw)
+
+  return 1
+}
+
 is_vibe_branch() {
   local branch prefix
   branch="$1"
@@ -1335,7 +1471,7 @@ resolve_vibe_branch() {
   fi
 
   branch="$(current_branch)"
-  is_vibe_branch "${branch}" || die "run this command inside a vibe worktree or pass a vibe name"
+  is_vibe_branch "${branch}" || die "run this command inside a vibe branch or pass a vibe name"
   printf '%s\n' "${branch}"
 }
 
@@ -1369,13 +1505,21 @@ accessible_worktree_path() {
   worktree_path_exists "${path}" && git -C "${path}" rev-parse --is-inside-work-tree >/dev/null 2>&1
 }
 
+branch_active_at_path() {
+  local path branch
+  path="$1"
+  branch="$2"
+  accessible_worktree_path "${path}" || return 1
+  [[ "$(current_branch_at_path "${path}")" == "${branch}" ]]
+}
+
 vibe_merge_base() {
   local base path branch
   base="$1"
   path="$2"
   branch="${3:-}"
 
-  if accessible_worktree_path "${path}"; then
+  if accessible_worktree_path "${path}" && [[ -z "${branch}" || "$(current_branch_at_path "${path}")" == "${branch}" ]]; then
     git -C "${path}" merge-base "${base}" HEAD
     return 0
   fi
@@ -1389,32 +1533,44 @@ vibe_merge_base() {
 }
 
 vibe_diff_shortstat() {
-  local merge_base path
+  local merge_base path branch
   merge_base="$1"
   path="$2"
+  branch="${3:-}"
 
-  accessible_worktree_path "${path}" || return 0
   [[ -n "${merge_base}" ]] || return 0
-  git -C "${path}" diff --shortstat "${merge_base}" || true
+
+  if accessible_worktree_path "${path}" && [[ -z "${branch}" || "$(current_branch_at_path "${path}")" == "${branch}" ]]; then
+    git -C "${path}" diff --shortstat "${merge_base}" || true
+    return 0
+  fi
+
+  [[ -n "${branch}" ]] || return 0
+  git diff --shortstat "${merge_base}..${branch}" || true
 }
 
 vibe_dirty_count() {
-  local path
+  local path branch
   path="$1"
+  branch="${2:-}"
 
-  accessible_worktree_path "${path}" || {
+  if ! accessible_worktree_path "${path}" || [[ -n "${branch}" && "$(current_branch_at_path "${path}")" != "${branch}" ]]; then
     printf '%s\n' "-"
     return 0
-  }
+  fi
 
   git -C "${path}" status --porcelain | wc -l | tr -d ' '
 }
 
 vibe_untracked_files() {
-  local path
+  local path branch
   path="$1"
+  branch="${2:-}"
 
-  accessible_worktree_path "${path}" || return 0
+  if ! accessible_worktree_path "${path}" || [[ -n "${branch}" && "$(current_branch_at_path "${path}")" != "${branch}" ]]; then
+    return 0
+  fi
+
   git -C "${path}" ls-files --others --exclude-standard
 }
 
@@ -1457,16 +1613,26 @@ worktree_state_label() {
   )
 }
 
+vibe_state_label() {
+  local branch path locked prunable
+  branch="$1"
+  path="$2"
+  locked="$3"
+  prunable="$4"
+
+  if [[ -n "${path}" ]]; then
+    worktree_state_label "${path}" "${locked}" "${prunable}"
+    return 0
+  fi
+
+  printf '%s\n' "branch-only"
+}
+
 worktree_change_summary() {
   local base branch path merge_base diff_summary untracked_count
   base="$1"
   branch="$2"
   path="$3"
-
-  if ! accessible_worktree_path "${path}"; then
-    printf '%s\n' "-"
-    return 0
-  fi
 
   merge_base="$(vibe_merge_base "${base}" "${path}" "${branch}" || true)"
   [[ -n "${merge_base}" ]] || {
@@ -1474,8 +1640,8 @@ worktree_change_summary() {
     return 0
   }
 
-  diff_summary="$(vibe_diff_shortstat "${merge_base}" "${path}")"
-  untracked_count="$(vibe_untracked_files "${path}" | wc -l | tr -d ' ')"
+  diff_summary="$(vibe_diff_shortstat "${merge_base}" "${path}" "${branch}")"
+  untracked_count="$(vibe_untracked_files "${path}" "${branch}" | wc -l | tr -d ' ')"
 
   if [[ -n "${diff_summary}" ]]; then
     printf '%s\n' "${diff_summary}"
@@ -1487,19 +1653,25 @@ worktree_change_summary() {
 }
 
 print_vibe_context() {
-  local branch path base merge_base diff_summary dirty_count behind ahead untracked_count issue_number issue_title issue_url
+  local branch path base merge_base diff_summary dirty_count behind ahead untracked_count issue_number issue_title issue_url backing active_checkout
   branch="$1"
   path="$2"
   base="$(base_branch)"
+  backing="$(vibe_backing_for_branch "${branch}")"
+  active_checkout="false"
+  if accessible_worktree_path "${path}" && [[ "$(current_branch_at_path "${path}")" == "${branch}" ]]; then
+    active_checkout="true"
+  fi
   merge_base="$(vibe_merge_base "${base}" "${path}" "${branch}" || true)"
-  diff_summary="$(vibe_diff_shortstat "${merge_base}" "${path}")"
-  dirty_count="$(vibe_dirty_count "${path}")"
-  untracked_count="$(vibe_untracked_files "${path}" | wc -l | tr -d ' ')"
+  diff_summary="$(vibe_diff_shortstat "${merge_base}" "${path}" "${branch}")"
+  dirty_count="$(vibe_dirty_count "${path}" "${branch}")"
+  untracked_count="$(vibe_untracked_files "${path}" "${branch}" | wc -l | tr -d ' ')"
   read -r behind ahead < <(git rev-list --left-right --count "${base}...${branch}" 2>/dev/null || printf '0 0\n')
 
   say "Context:"
   say "  Branch: ${branch}"
   say "  Base: ${base}"
+  say "  Backing: ${backing}"
   say "  Path: ${path}"
   say "  Compare: ${base}...${branch}"
   say "  Ahead/behind vs ${base}: +${ahead}/-${behind}"
@@ -1522,18 +1694,20 @@ print_vibe_context() {
 
   if ! accessible_worktree_path "${path}"; then
     say "  Working tree: unavailable (worktree path missing)"
+  elif [[ "${active_checkout}" != "true" ]]; then
+    say "  Working tree: branch is not currently checked out in this path"
   elif [[ "${dirty_count}" == "0" ]]; then
     say "  Working tree: clean"
   else
     say "  Working tree: ${dirty_count} uncommitted change(s)"
   fi
 
-  if ! accessible_worktree_path "${path}"; then
-    say "  Changes vs ${base}: unavailable"
-  elif [[ -n "${diff_summary}" ]]; then
+  if [[ -n "${diff_summary}" ]]; then
     say "  Changes vs ${base}: ${diff_summary}"
   elif [[ "${untracked_count}" != "0" ]]; then
     say "  Changes vs ${base}: ${untracked_count} untracked file(s)"
+  elif ! accessible_worktree_path "${path}"; then
+    say "  Changes vs ${base}: unavailable"
   else
     say "  Changes vs ${base}: none"
   fi
@@ -1602,13 +1776,13 @@ print_help() {
 Git Vibe
 
 Usage:
-  git vibe code [--editor|--no-editor] [--codex|--vscode] [--agent <agent>] [--task <task>] <name>
-  git vibe issue [--editor|--no-editor] [--codex|--vscode] [--agent <agent>] [--task <task>] <number>
+  git vibe code [--solo|--worktree] [--editor|--no-editor] [--codex|--vscode] [--agent <agent>] [--task <task>] <name>
+  git vibe issue [--solo|--worktree] [--editor|--no-editor] [--codex|--vscode] [--agent <agent>] [--task <task>] <number>
   git vibe session [--agent <agent>] [--task <task>] [--clear] [name]
   git vibe pr [--draft] [--web] [--title <title>] [--body <body>] [name]
   git vibe submit [--draft] [--web] [--title <title>] [--body <body>] [name]
   git vibe checks [name]
-  git vibe enter [name]
+  git vibe enter [--editor|--no-editor] [--codex|--vscode] [name]
   git vibe open [--codex|--vscode] [name]
   git vibe diff [name]
   git vibe finish [--local] [--sync] [--delete-remote|--keep-remote] [name]
@@ -1625,6 +1799,7 @@ Usage:
 
 Examples:
   git vibe code fallback-app-urls
+  git vibe code --solo fallback-app-urls
   git vibe code --agent codex --task "fix login redirect" fallback-app-urls
   git vibe code 9
   git vibe issue 9
@@ -1634,6 +1809,7 @@ Examples:
   git vibe checks 10
   git vibe code --codex fallback-app-urls
   git vibe code --no-editor fallback-app-urls
+  git vibe enter --vscode fallback-app-urls
   git vibe enter fallback-app-urls
   git vibe open fallback-app-urls
   git vibe diff fallback-app-urls
@@ -1682,7 +1858,7 @@ open_workspace_for_path() {
 }
 
 command_code() {
-  local name slug branch base path shell_output open_editor action base_path editor_mode workspace_app workspace_app_override
+  local name slug branch base path shell_output open_editor action base_path editor_mode workspace_app workspace_app_override mode_override requested_mode
   local session_agent session_task current_session_agent current_session_task final_session_agent final_session_task detected_session_agent
   local agent_set task_set
   local issue_number issue_title issue_url issue_metadata
@@ -1692,6 +1868,7 @@ command_code() {
   shell_output="false"
   open_editor=""
   workspace_app_override=""
+  mode_override=""
   session_agent=""
   session_task=""
   agent_set="false"
@@ -1714,6 +1891,12 @@ command_code() {
         ;;
       --vscode)
         workspace_app_override="vscode"
+        ;;
+      --solo)
+        mode_override="solo"
+        ;;
+      --worktree)
+        mode_override="worktree"
         ;;
       --agent)
         shift
@@ -1764,43 +1947,68 @@ command_code() {
     branch="$(branch_from_slug "${slug}")"
   fi
 
+  requested_mode="$(resolve_vibe_mode "${mode_override}")"
   base="$(base_branch)"
   path="$(worktree_path_for_slug "${slug}")"
   action="Opened"
 
   if find_worktree_for_branch "${branch}" >/dev/null 2>&1; then
     path="$(find_worktree_for_branch "${branch}")"
-  elif branch_exists "${branch}"; then
-    if [[ -e "${path}" ]]; then
-      die "worktree path already exists: ${path}"
+    requested_mode="$(vibe_backing_for_branch "${branch}")"
+  elif [[ "${requested_mode}" == "solo" ]]; then
+    path="$(repo_root)"
+
+    if branch_exists "${branch}"; then
+      if [[ "$(current_branch)" == "${branch}" ]]; then
+        action="Opened"
+      else
+        ensure_clean_tree "${path}"
+        git -C "${path}" switch "${branch}" >/dev/null
+        action="Switched"
+      fi
+    elif remote_branch_exists "origin/${branch}"; then
+      ensure_clean_tree "${path}"
+      git -C "${path}" switch -c "${branch}" --track "origin/${branch}" >/dev/null
+      action="Checked out"
+    else
+      branch_exists "${base}" || die "base branch ${base} does not exist locally"
+      ensure_clean_tree "${path}"
+      git -C "${path}" switch -c "${branch}" "${base}" >/dev/null
+      action="Started"
     fi
-    mkdir -p "$(vibe_root)"
-    git worktree add "${path}" "${branch}"
-    action="Attached"
-  elif remote_branch_exists "origin/${branch}"; then
-    if [[ -e "${path}" ]]; then
-      die "worktree path already exists: ${path}"
-    fi
-    mkdir -p "$(vibe_root)"
-    git worktree add -b "${branch}" "${path}" "origin/${branch}"
-    git -C "${path}" branch --set-upstream-to "origin/${branch}" "${branch}" >/dev/null 2>&1 || true
-    action="Checked out"
   else
-    branch_exists "${base}" || die "base branch ${base} does not exist locally"
-    base_path="$(base_worktree_path || true)"
+    if branch_exists "${branch}"; then
+      if [[ -e "${path}" ]]; then
+        die "worktree path already exists: ${path}"
+      fi
+      mkdir -p "$(vibe_root)"
+      git worktree add "${path}" "${branch}"
+      action="Attached"
+    elif remote_branch_exists "origin/${branch}"; then
+      if [[ -e "${path}" ]]; then
+        die "worktree path already exists: ${path}"
+      fi
+      mkdir -p "$(vibe_root)"
+      git worktree add -b "${branch}" "${path}" "origin/${branch}"
+      git -C "${path}" branch --set-upstream-to "origin/${branch}" "${branch}" >/dev/null 2>&1 || true
+      action="Checked out"
+    else
+      branch_exists "${base}" || die "base branch ${base} does not exist locally"
+      base_path="$(base_worktree_path || true)"
 
-    if [[ -n "${base_path}" ]]; then
-      ensure_clean_tree "${base_path}"
-      git -C "${base_path}" switch "${base}" >/dev/null 2>&1 || true
+      if [[ -n "${base_path}" ]]; then
+        ensure_clean_tree "${base_path}"
+        git -C "${base_path}" switch "${base}" >/dev/null 2>&1 || true
+      fi
+
+      if [[ -e "${path}" ]]; then
+        die "worktree path already exists: ${path}"
+      fi
+
+      mkdir -p "$(vibe_root)"
+      git worktree add -b "${branch}" "${path}" "${base}"
+      action="Started"
     fi
-
-    if [[ -e "${path}" ]]; then
-      die "worktree path already exists: ${path}"
-    fi
-
-    mkdir -p "$(vibe_root)"
-    git worktree add -b "${branch}" "${path}" "${base}"
-    action="Started"
   fi
 
   if [[ -n "${issue_number}" ]]; then
@@ -1832,7 +2040,9 @@ command_code() {
     touch_session_metadata "${branch}"
   fi
 
-  if [[ "${action}" != "Opened" ]]; then
+  remember_branch_workspace "${branch}" "${requested_mode}" "${path}"
+
+  if [[ "${action}" != "Opened" && "${requested_mode}" == "worktree" ]]; then
     apply_shared_paths "${path}"
     run_configured_hook "post-create" "${path}" "${branch}" "${path}"
   fi
@@ -1881,7 +2091,7 @@ command_issue() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --shell-output|--editor|--no-editor|--codex|--vscode)
+      --shell-output|--editor|--no-editor|--codex|--vscode|--solo|--worktree)
         ;;
       --agent|--task)
         local flag_name
@@ -2067,17 +2277,33 @@ command_submit() {
 }
 
 command_enter() {
-  local branch path shell_output
+  local branch path shell_output backing editor_mode workspace_app workspace_app_override open_editor
   local -a name_parts
   require_repo
 
   shell_output="false"
+  workspace_app_override=""
+  open_editor=""
   name_parts=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --shell-output)
         shell_output="true"
+        ;;
+      --editor)
+        open_editor="always"
+        ;;
+      --no-editor)
+        open_editor="never"
+        ;;
+      --codex)
+        workspace_app_override="codex"
+        open_editor="always"
+        ;;
+      --vscode)
+        workspace_app_override="vscode"
+        open_editor="always"
         ;;
       -h|--help)
         print_help
@@ -2091,12 +2317,45 @@ command_enter() {
   done
 
   branch="$(resolve_vibe_branch "${name_parts[@]}")"
+  backing="$(vibe_backing_for_branch "${branch}")"
   touch_session_metadata "${branch}"
-  path="$(worktree_path_for_branch "${branch}")"
+
+  if [[ "${backing}" == "worktree" ]]; then
+    path="$(worktree_path_for_branch "${branch}")"
+  else
+    path="$(repo_root)"
+    if [[ "$(current_branch)" != "${branch}" ]]; then
+      ensure_clean_tree "${path}"
+      git -C "${path}" switch "${branch}" >/dev/null
+    fi
+  fi
 
   say "Entering ${branch}"
   say "Path: ${path}"
   print_vibe_context "${branch}" "${path}"
+
+  if [[ "${shell_output}" != "true" ]]; then
+    editor_mode="never"
+    if [[ "${backing}" == "solo" ]]; then
+      editor_mode="$(open_editor_mode)"
+    fi
+    if [[ -n "${open_editor}" ]]; then
+      editor_mode="${open_editor}"
+    fi
+
+    if should_open_editor "${editor_mode}"; then
+      workspace_app="$(workspace_app_setting)"
+      if [[ -n "${workspace_app_override}" ]]; then
+        workspace_app="${workspace_app_override}"
+      fi
+      workspace_app="$(resolve_workspace_app "${workspace_app}")"
+      if [[ -n "${workspace_app}" ]]; then
+        open_workspace_for_path "${path}" "${workspace_app}"
+      else
+        say "Workspace: skipped (no supported app found)"
+      fi
+    fi
+  fi
 
   if [[ "${shell_output}" == "true" ]]; then
     say_shell_chdir "${path}"
@@ -2104,7 +2363,7 @@ command_enter() {
 }
 
 command_open() {
-  local branch path workspace_app
+  local branch path workspace_app backing
   local -a name_parts
   require_repo
 
@@ -2131,8 +2390,19 @@ command_open() {
   done
 
   branch="$(resolve_vibe_branch "${name_parts[@]}")"
+  backing="$(vibe_backing_for_branch "${branch}")"
   touch_session_metadata "${branch}"
-  path="$(worktree_path_for_branch "${branch}")"
+
+  if [[ "${backing}" == "worktree" ]]; then
+    path="$(worktree_path_for_branch "${branch}")"
+  else
+    path="$(repo_root)"
+    if [[ "$(current_branch)" != "${branch}" ]]; then
+      ensure_clean_tree "${path}"
+      git -C "${path}" switch "${branch}" >/dev/null
+    fi
+  fi
+
   workspace_app="$(resolve_workspace_app "${workspace_app}")"
   [[ -n "${workspace_app}" ]] || die "no supported workspace app found; install 'code' or 'codex'"
 
@@ -2168,13 +2438,17 @@ command_diff() {
 
   branch="$(resolve_vibe_branch "$@")"
   touch_session_metadata "${branch}"
-  path="$(worktree_path_for_branch "${branch}")"
+  path="$(vibe_path_for_branch "${branch}")"
   base="$(base_branch)"
-  merge_base="$(vibe_merge_base "${base}" "${path}")"
+  merge_base="$(vibe_merge_base "${base}" "${path}" "${branch}")"
 
-  git -C "${path}" diff "${merge_base}"
+  if accessible_worktree_path "${path}" && [[ "$(current_branch_at_path "${path}")" == "${branch}" ]]; then
+    git -C "${path}" diff "${merge_base}"
+  else
+    git diff "${merge_base}..${branch}"
+  fi
 
-  untracked_files="$(vibe_untracked_files "${path}")"
+  untracked_files="$(vibe_untracked_files "${path}" "${branch}")"
   if [[ -n "${untracked_files}" ]]; then
     say ""
     say "Untracked files:"
@@ -2183,7 +2457,7 @@ command_diff() {
 }
 
 command_finish() {
-  local name branch slug path mode sync base merged_into shell_output base_path delete_remote delete_remote_override
+  local name branch slug path mode sync base merged_into shell_output base_path delete_remote delete_remote_override backing active_path
   local -a name_parts
   require_repo
 
@@ -2247,15 +2521,19 @@ command_finish() {
   fi
 
   branch_exists "${branch}" || die "branch ${branch} does not exist locally"
-  path="$(find_worktree_for_branch "${branch}" || true)"
-  [[ -n "${path}" ]] || path="$(worktree_path_for_slug "${slug}")"
+  backing="$(vibe_backing_for_branch "${branch}")"
+  active_path="$(find_worktree_for_branch "${branch}" || true)"
+  path="$(vibe_path_for_branch "${branch}")"
+  if [[ "${backing}" == "solo" ]]; then
+    base_path="$(repo_root)"
+  fi
 
   if [[ "${sync}" == "true" ]]; then
     run_fetch
   fi
 
-  if [[ -d "${path}" ]]; then
-    ensure_clean_tree "${path}"
+  if [[ -n "${active_path}" && -d "${active_path}" ]]; then
+    ensure_clean_tree "${active_path}"
   fi
 
   merged_into=""
@@ -2263,13 +2541,24 @@ command_finish() {
   if is_ancestor_of "${branch}" "${base}"; then
     merged_into="${base}"
   elif remote_branch_exists "origin/${base}" && is_ancestor_of "${branch}" "origin/${base}"; then
-    sync_base_branch
-    base_path="$(base_worktree_path || true)"
-    [[ -n "${base_path}" ]] || base_path="$(repo_root)"
+    if [[ "${backing}" == "worktree" ]]; then
+      sync_base_branch
+      base_path="$(base_worktree_path || true)"
+      [[ -n "${base_path}" ]] || base_path="$(repo_root)"
+    else
+      base_path="$(repo_root)"
+      ensure_clean_tree "${base_path}"
+      git -C "${base_path}" switch "${base}" >/dev/null 2>&1 || true
+      git -C "${base_path}" merge --ff-only "origin/${base}" >/dev/null
+    fi
     merged_into="origin/${base}"
   elif [[ "${mode}" == "local" ]]; then
-    base_path="$(base_worktree_path || true)"
-    [[ -n "${base_path}" ]] || die "could not find a worktree for ${base}"
+    if [[ "${backing}" == "worktree" ]]; then
+      base_path="$(base_worktree_path || true)"
+      [[ -n "${base_path}" ]] || die "could not find a worktree for ${base}"
+    else
+      base_path="$(repo_root)"
+    fi
     ensure_clean_tree "${base_path}"
     git -C "${base_path}" switch "${base}" >/dev/null 2>&1 || true
     git -C "${base_path}" merge --ff-only "${branch}"
@@ -2281,7 +2570,11 @@ command_finish() {
   [[ -n "${base_path}" ]] || die "could not find a stable worktree for ${base}"
 
   if [[ -d "${path}" ]]; then
-    run_configured_hook "pre-finish" "${path}" "${branch}" "${path}"
+    if [[ "${backing}" == "worktree" ]]; then
+      run_configured_hook "pre-finish" "${path}" "${branch}" "${path}"
+    else
+      run_configured_hook "pre-finish" "${base_path}" "${branch}" "${path}"
+    fi
   else
     run_configured_hook "pre-finish" "${base_path}" "${branch}" "${path}"
   fi
@@ -2296,12 +2589,17 @@ command_finish() {
   (
     cd "${base_path}" >/dev/null 2>&1 || die "could not enter ${base_path}"
 
-    if [[ -d "${path}" ]]; then
+    if [[ "$(current_branch)" != "${base}" ]]; then
+      git switch "${base}" >/dev/null 2>&1 || true
+    fi
+
+    if [[ "${backing}" == "worktree" && -d "${path}" ]]; then
       git worktree remove "${path}"
     fi
 
     git branch -d "${branch}" >/dev/null
     clear_session_metadata "${branch}"
+    clear_branch_workspace "${branch}"
     git worktree prune >/dev/null 2>&1 || true
   )
 
@@ -2432,23 +2730,39 @@ repair_worktree_metadata() {
 
 command_list() {
   local base branch path head detached bare locked locked_reason prunable prunable_reason
-  local state ahead session changes found
+  local state ahead session changes found record display_path
   require_repo
   base="$(base_branch)"
   found="false"
 
-  while IFS=$'\t' read -r branch path head detached bare locked locked_reason prunable prunable_reason; do
+  while IFS= read -r branch; do
+    [[ -n "${branch}" ]] || continue
+
+    path=""
+    head=""
+    detached="false"
+    bare="false"
+    locked="false"
+    locked_reason=""
+    prunable="false"
+    prunable_reason=""
+    record="$(worktree_record_for_branch "${branch}" || true)"
+    if [[ -n "${record}" ]]; then
+      IFS=$'\t' read -r branch path head detached bare locked locked_reason prunable prunable_reason <<< "${record}"
+    fi
+
     if [[ "${found}" == "false" ]]; then
       printf '%-32s %-18s %-10s %-32s %-32s %s\n' "BRANCH" "STATE" "AHEAD" "SESSION" "CHANGES" "PATH"
       found="true"
     fi
 
-    state="$(worktree_state_label "${path}" "${locked}" "${prunable}")"
+    display_path="${path:-$(vibe_path_for_branch "${branch}")}"
+    state="$(vibe_state_label "${branch}" "${path}" "${locked}" "${prunable}")"
     ahead="$(vibe_ahead_behind_summary "${base}" "${branch}")"
     session="$(session_summary_for_branch "${branch}")"
-    changes="$(worktree_change_summary "${base}" "${branch}" "${path}")"
-    printf '%-32s %-18s %-10s %-32s %-32s %s\n' "${branch}" "${state}" "${ahead}" "${session}" "${changes}" "${path}"
-  done < <(list_vibes_raw)
+    changes="$(worktree_change_summary "${base}" "${branch}" "${display_path}")"
+    printf '%-32s %-18s %-10s %-32s %-32s %s\n' "${branch}" "${state}" "${ahead}" "${session}" "${changes}" "${display_path}"
+  done < <(local_vibe_branches_raw)
 
   if [[ "${found}" == "false" ]]; then
     say "No active vibes"
@@ -2456,7 +2770,7 @@ command_list() {
 }
 
 command_status() {
-  local base current prefix root editor_mode workspace_app issue_style delete_remote_finish shared_paths branch path
+  local base current prefix root editor_mode workspace_app issue_style delete_remote_finish shared_paths branch path mode
   local repo_config_path hooks_summary
   local -a name_parts
   require_repo
@@ -2479,6 +2793,7 @@ command_status() {
   current="$(current_branch)"
   prefix="$(branch_prefix)"
   root="$(vibe_root)"
+  mode="$(vibe_mode_setting)"
   editor_mode="$(open_editor_mode)"
   workspace_app="$(workspace_app_setting)"
   issue_style="$(issue_branch_style)"
@@ -2490,12 +2805,14 @@ command_status() {
   validate_workspace_app "${workspace_app}"
   validate_issue_branch_style "${issue_style}"
   validate_delete_remote_on_finish "${delete_remote_finish}"
+  validate_vibe_mode "${mode}"
 
   say "Repo: $(repo_root)"
   say "Repo config: ${repo_config_path:-none}"
   say "Base branch: ${base}"
   say "Current branch: ${current}"
   say "Branch prefix: ${prefix}"
+  say "Mode: ${mode}"
   say "Vibe root: ${root}"
   say "Open editor: ${editor_mode}"
   say "Open workspace with: ${workspace_app}"
@@ -2508,7 +2825,7 @@ command_status() {
   if [[ ${#name_parts[@]} -gt 0 ]]; then
     branch="$(resolve_vibe_branch "${name_parts[@]}")"
     touch_session_metadata "${branch}"
-    path="$(worktree_path_for_branch "${branch}")"
+    path="$(vibe_path_for_branch "${branch}")"
     print_vibe_context "${branch}" "${path}"
     print_pr_context "${branch}"
     return 0
@@ -2546,8 +2863,11 @@ command_path() {
     slug="$(slug_from_branch "${branch}")"
   fi
 
-  path="$(find_worktree_for_branch "${branch}" || true)"
-  printf '%s\n' "${path:-$(worktree_path_for_slug "${slug}")}"
+  if branch_exists "${branch}"; then
+    printf '%s\n' "$(vibe_path_for_branch "${branch}")"
+  else
+    printf '%s\n' "$(worktree_path_for_slug "${slug}")"
+  fi
 }
 
 command_prune() {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -16,6 +16,10 @@ CONFIG_WORKTREE_DIR="${TMP_DIR}/repo-vibes/config-demo/repo-config-demo"
 WORKTREE_FINISH_DIR="${TMP_DIR}/.vibe/demo/worktree-finish"
 ISSUE_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/9-issue-aware-vibe-creation"
 TITLE_ONLY_ISSUE_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/issue-title-only-branch"
+SOLO_MODE_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/solo-mode"
+SOLO_ISSUE_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/11-solo-mode-issue"
+SOLO_WORKTREE_OVERRIDE_DIR="${TMP_DIR}/.vibe/demo/solo-worktree-override"
+FORCED_SOLO_OVERRIDE_DIR="${TMP_DIR}/.vibe/demo/forced-solo-override"
 SESSION_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/session-demo"
 DOCTOR_DIRTY_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/doctor-dirty"
 DOCTOR_STALE_WORKTREE_DIR="${TMP_DIR}/.vibe/demo/doctor-stale"
@@ -36,6 +40,7 @@ CODE_LOG="${TMP_DIR}/code.log"
 CODEX_LOG="${TMP_DIR}/codex.log"
 ISSUE_9_TITLE_FILE="${TMP_DIR}/issue-9-title.txt"
 ISSUE_10_TITLE_FILE="${TMP_DIR}/issue-10-title.txt"
+ISSUE_11_TITLE_FILE="${TMP_DIR}/issue-11-title.txt"
 PR_NUMBER_FILE="${TMP_DIR}/pr-number.txt"
 PR_URL_FILE="${TMP_DIR}/pr-url.txt"
 PR_TITLE_FILE="${TMP_DIR}/pr-title.txt"
@@ -104,6 +109,9 @@ if [ "\${1:-}" = "issue" ] && [ "\${2:-}" = "view" ]; then
       ;;
     10)
       title="\$(<"${ISSUE_10_TITLE_FILE}")"
+      ;;
+    11)
+      title="\$(<"${ISSUE_11_TITLE_FILE}")"
       ;;
     *)
       printf 'fake gh: unknown issue %s\n' "\${number}" >&2
@@ -221,6 +229,7 @@ chmod +x "${FAKE_BIN_DIR}/gh"
 
 printf 'Issue aware vibe creation\n' > "${ISSUE_9_TITLE_FILE}"
 printf 'Issue title only branch\n' > "${ISSUE_10_TITLE_FILE}"
+printf 'Solo mode issue\n' > "${ISSUE_11_TITLE_FILE}"
 printf '24\n' > "${PR_NUMBER_FILE}"
 printf 'https://github.com/sailscastshq/git-vibe/pull/24\n' > "${PR_URL_FILE}"
 
@@ -247,6 +256,7 @@ VIBE_ALLOW_COMMIT_BASE=1 git -C "${REPO_DIR}" commit -m "chore: initial commit" 
 git -C "${REPO_DIR}" remote add origin "${ORIGIN_DIR}"
 git -C "${REPO_DIR}" config vibe.baseBranch main
 git -C "${REPO_DIR}" config vibe.branchPrefix feat/
+git -C "${REPO_DIR}" config vibe.mode worktree
 git -C "${REPO_DIR}" config vibe.worktreeRoot ../.vibe
 git -C "${REPO_DIR}" config vibe.disallowPushOnBase false
 git -C "${REPO_DIR}" push -u origin main >/dev/null
@@ -264,6 +274,7 @@ printf '0.0.0\n' > "${CONFIG_REPO_DIR}/VERSION"
 printf 'node_modules/\n.venv/\n' > "${CONFIG_REPO_DIR}/.gitignore"
 cat > "${CONFIG_REPO_DIR}/vibe.toml" <<EOF
 [vibe]
+mode = "worktree"
 worktreeRoot = "../repo-vibes"
 openEditor = "never"
 openWorkspaceWith = "vscode"
@@ -287,6 +298,7 @@ printf 'module.exports = {}\n' > "${CONFIG_REPO_DIR}/node_modules/sails/index.js
 printf '#!/usr/bin/env bash\n' > "${CONFIG_REPO_DIR}/.venv/bin/python"
 
 git config --file "${CONFIG_GLOBAL_FILE}" vibe.worktreeRoot ../global-vibes
+git config --file "${CONFIG_GLOBAL_FILE}" vibe.mode solo
 git config --file "${CONFIG_GLOBAL_FILE}" vibe.openEditor always
 git config --file "${CONFIG_GLOBAL_FILE}" vibe.deleteRemoteOnFinish false
 
@@ -296,12 +308,14 @@ CONFIG_STATUS_OUTPUT="$(
 )"
 [[ "${CONFIG_STATUS_OUTPUT}" == *"Repo config: ${CONFIG_REPO_DIR}/vibe.toml"* ]] || fail "check did not show the checked-in vibe.toml path"
 [[ "${CONFIG_STATUS_OUTPUT}" == *"Vibe root: ${TMP_DIR}/repo-vibes/config-demo"* ]] || fail "repo vibe.toml should override the global worktree root"
+[[ "${CONFIG_STATUS_OUTPUT}" == *"Mode: worktree"* ]] || fail "repo vibe.toml should override the global mode"
 [[ "${CONFIG_STATUS_OUTPUT}" == *"Open editor: never"* ]] || fail "repo vibe.toml should override the global openEditor setting"
 [[ "${CONFIG_STATUS_OUTPUT}" == *"Delete remote on finish: true"* ]] || fail "repo vibe.toml should override the global deleteRemoteOnFinish setting"
 [[ "${CONFIG_STATUS_OUTPUT}" == *"Shared paths: node_modules, .venv"* ]] || fail "check did not summarize repo-configured shared paths"
 [[ "${CONFIG_STATUS_OUTPUT}" == *"Hooks: post-create, pre-finish, pre-release"* ]] || fail "check did not summarize the configured lifecycle hooks"
 
 git -C "${CONFIG_REPO_DIR}" config vibe.worktreeRoot ../local-vibes
+git -C "${CONFIG_REPO_DIR}" config vibe.mode solo
 git -C "${CONFIG_REPO_DIR}" config vibe.openEditor auto
 git -C "${CONFIG_REPO_DIR}" config vibe.deleteRemoteOnFinish false
 
@@ -310,11 +324,13 @@ CONFIG_LOCAL_OVERRIDE_OUTPUT="$(
   GIT_CONFIG_GLOBAL="${CONFIG_GLOBAL_FILE}" "${ROOT}/bin/git-vibe" check
 )"
 [[ "${CONFIG_LOCAL_OVERRIDE_OUTPUT}" == *"Vibe root: ${TMP_DIR}/local-vibes/config-demo"* ]] || fail "local git config should override the checked-in vibe.toml worktree root"
+[[ "${CONFIG_LOCAL_OVERRIDE_OUTPUT}" == *"Mode: solo"* ]] || fail "local git config should override the checked-in vibe.toml mode"
 [[ "${CONFIG_LOCAL_OVERRIDE_OUTPUT}" == *"Open editor: auto"* ]] || fail "local git config should override the checked-in vibe.toml openEditor setting"
 [[ "${CONFIG_LOCAL_OVERRIDE_OUTPUT}" == *"Delete remote on finish: false"* ]] || fail "local git config should override the checked-in vibe.toml deleteRemoteOnFinish setting"
 [[ "${CONFIG_LOCAL_OVERRIDE_OUTPUT}" == *"Shared paths: node_modules, .venv"* ]] || fail "local git config should still inherit shared paths from repo vibe.toml"
 
 git -C "${CONFIG_REPO_DIR}" config --unset vibe.worktreeRoot
+git -C "${CONFIG_REPO_DIR}" config --unset vibe.mode
 git -C "${CONFIG_REPO_DIR}" config --unset vibe.openEditor
 git -C "${CONFIG_REPO_DIR}" config --unset vibe.deleteRemoteOnFinish
 
@@ -578,6 +594,161 @@ git -C "${REPO_DIR}" config --unset vibe.issueBranchStyle
 git -C "${REPO_DIR}" config --unset vibe.deleteRemoteOnFinish
 
 printf 'smoke: issue flow ok\n'
+
+git -C "${REPO_DIR}" config vibe.mode solo
+
+SOLO_CODE_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" code solo-mode
+)"
+[[ ! -d "${SOLO_MODE_WORKTREE_DIR}" ]] || fail "solo mode should not create a worktree for code"
+[[ "${SOLO_CODE_OUTPUT}" == *"Started feat/solo-mode"* ]] || fail "solo mode code did not create the expected branch"
+[[ "${SOLO_CODE_OUTPUT}" == *"Backing: solo"* ]] || fail "solo mode code did not print the solo backing"
+[[ "${SOLO_CODE_OUTPUT}" == *"Path: ${REPO_DIR}"* ]] || fail "solo mode code did not use the repo root path"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/solo-mode" ]] || fail "solo mode code did not switch the current checkout"
+
+printf '\nSolo mode change\n' >> "${REPO_DIR}/README.md"
+git -C "${REPO_DIR}" add README.md
+git -C "${REPO_DIR}" commit -m "feat: update readme in solo mode" >/dev/null
+
+SOLO_PATH_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" path solo-mode
+)"
+[[ "${SOLO_PATH_OUTPUT}" == "${REPO_DIR}" ]] || fail "path should return the repo root for a solo vibe"
+
+git -C "${REPO_DIR}" switch main >/dev/null
+
+SOLO_LIST_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" list
+)"
+[[ "${SOLO_LIST_OUTPUT}" == *"feat/solo-mode"* ]] || fail "list did not include the solo vibe branch"
+[[ "${SOLO_LIST_OUTPUT}" == *"branch-only"* ]] || fail "list did not label the inactive solo vibe as branch-only"
+[[ "${SOLO_LIST_OUTPUT}" == *"${REPO_DIR}"* ]] || fail "list did not show the repo root path for the solo vibe"
+
+SOLO_STATUS_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" check solo-mode
+)"
+[[ "${SOLO_STATUS_OUTPUT}" == *"Mode: solo"* ]] || fail "check did not report solo mode"
+[[ "${SOLO_STATUS_OUTPUT}" == *"Backing: solo"* ]] || fail "check did not show the solo backing"
+[[ "${SOLO_STATUS_OUTPUT}" == *"Working tree: branch is not currently checked out in this path"* ]] || fail "check did not explain inactive solo branch state"
+
+SOLO_ENTER_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" enter solo-mode --shell-output
+)"
+[[ "${SOLO_ENTER_OUTPUT}" == *"Entering feat/solo-mode"* ]] || fail "enter did not announce the solo vibe"
+[[ "${SOLO_ENTER_OUTPUT}" == *"__GIT_VIBE_CHDIR__=${REPO_DIR}"* ]] || fail "enter did not keep solo mode in the repo root"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/solo-mode" ]] || fail "enter did not switch back to the solo vibe branch"
+
+git -C "${REPO_DIR}" switch main >/dev/null
+: > "${CODE_LOG}"
+
+SOLO_ENTER_OPEN_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" enter --vscode solo-mode
+)"
+[[ "${SOLO_ENTER_OPEN_OUTPUT}" == *"Entering feat/solo-mode"* ]] || fail "enter --vscode did not target the solo vibe branch"
+[[ -s "${CODE_LOG}" ]] || fail "enter --vscode should launch VS Code for a solo vibe"
+[[ "$(<"${CODE_LOG}")" == *"${REPO_DIR}"* ]] || fail "enter --vscode should open the repo root for a solo vibe"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/solo-mode" ]] || fail "enter --vscode did not switch to the solo vibe branch"
+
+git -C "${REPO_DIR}" switch main >/dev/null
+: > "${CODE_LOG}"
+
+SOLO_OPEN_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" open --vscode solo-mode
+)"
+[[ "${SOLO_OPEN_OUTPUT}" == *"Opening feat/solo-mode"* ]] || fail "open did not target the solo vibe branch"
+[[ -s "${CODE_LOG}" ]] || fail "open --vscode should launch VS Code for a solo vibe"
+[[ "$(<"${CODE_LOG}")" == *"${REPO_DIR}"* ]] || fail "open --vscode should open the repo root for a solo vibe"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/solo-mode" ]] || fail "open did not switch to the solo vibe branch"
+
+git -C "${REPO_DIR}" switch main >/dev/null
+
+SOLO_FINISH_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" finish --local solo-mode
+)"
+[[ "${SOLO_FINISH_OUTPUT}" == *"Finished feat/solo-mode"* ]] || fail "finish --local did not close the solo vibe"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "main" ]] || fail "finish --local should leave solo mode on main"
+if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/solo-mode; then
+  fail "finish --local did not delete the solo vibe branch"
+fi
+
+: > "${CODE_LOG}"
+SOLO_START_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" start start-solo
+)"
+[[ ! -d "${TMP_DIR}/.vibe/demo/start-solo" ]] || fail "solo mode start should not create a worktree"
+[[ "${SOLO_START_OUTPUT}" == *"Started feat/start-solo"* ]] || fail "start did not create the expected solo branch"
+[[ ! -s "${CODE_LOG}" ]] || fail "start should keep the editor closed"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/start-solo" ]] || fail "start did not switch to the solo branch"
+git -C "${REPO_DIR}" switch main >/dev/null
+(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" finish start-solo >/dev/null
+)
+if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/start-solo; then
+  fail "finish did not delete the solo start branch"
+fi
+
+SOLO_ISSUE_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  PATH="${FAKE_BIN_DIR}:$PATH" "${ROOT}/bin/git-vibe" issue 11
+)"
+[[ ! -d "${SOLO_ISSUE_WORKTREE_DIR}" ]] || fail "solo mode issue should not create a worktree"
+[[ "${SOLO_ISSUE_OUTPUT}" == *"Started feat/11-solo-mode-issue"* ]] || fail "issue did not create the expected solo issue branch"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/11-solo-mode-issue" ]] || fail "issue did not switch to the solo issue branch"
+git -C "${REPO_DIR}" switch main >/dev/null
+(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" finish 11 >/dev/null
+)
+if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/11-solo-mode-issue; then
+  fail "finish did not delete the solo issue branch"
+fi
+
+SOLO_WORKTREE_OVERRIDE_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" code --worktree solo-worktree-override
+)"
+[[ -d "${SOLO_WORKTREE_OVERRIDE_DIR}" ]] || fail "--worktree should override solo mode and create a worktree"
+[[ "${SOLO_WORKTREE_OVERRIDE_OUTPUT}" == *"Path: ${SOLO_WORKTREE_OVERRIDE_DIR}"* ]] || fail "--worktree did not use the worktree path"
+git -C "${REPO_DIR}" worktree remove "${SOLO_WORKTREE_OVERRIDE_DIR}" >/dev/null
+git -C "${REPO_DIR}" branch -d feat/solo-worktree-override >/dev/null
+
+git -C "${REPO_DIR}" config --unset vibe.mode
+
+FORCED_SOLO_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" code --solo forced-solo-override
+)"
+[[ ! -d "${FORCED_SOLO_OVERRIDE_DIR}" ]] || fail "--solo should override worktree mode and stay in the repo root"
+[[ "${FORCED_SOLO_OUTPUT}" == *"Started feat/forced-solo-override"* ]] || fail "--solo did not create the expected branch"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "feat/forced-solo-override" ]] || fail "--solo did not switch the current checkout"
+
+printf '\nForced solo override change\n' >> "${REPO_DIR}/README.md"
+git -C "${REPO_DIR}" add README.md
+git -C "${REPO_DIR}" commit -m "feat: update readme for forced solo override" >/dev/null
+
+FORCED_SOLO_FINISH_OUTPUT="$(
+  cd "${REPO_DIR}" >/dev/null
+  "${ROOT}/bin/git-vibe" finish --local
+)"
+[[ "${FORCED_SOLO_FINISH_OUTPUT}" == *"Finished feat/forced-solo-override"* ]] || fail "finish --local did not close the active solo branch"
+[[ "$(git -C "${REPO_DIR}" branch --show-current)" == "main" ]] || fail "finish --local without a name should leave solo mode on main"
+if git -C "${REPO_DIR}" show-ref --verify --quiet refs/heads/feat/forced-solo-override; then
+  fail "finish --local did not delete the active solo branch"
+fi
+
+git -C "${REPO_DIR}" config vibe.mode worktree
+
+printf 'smoke: solo mode ok\n'
 
 SESSION_CODE_OUTPUT="$(
   cd "${REPO_DIR}" >/dev/null
@@ -881,6 +1052,7 @@ git -C "${SHELL_REPO_DIR}" add README.md
 VIBE_ALLOW_COMMIT_BASE=1 git -C "${SHELL_REPO_DIR}" commit -m "chore: initial commit" >/dev/null
 git -C "${SHELL_REPO_DIR}" config vibe.baseBranch main
 git -C "${SHELL_REPO_DIR}" config vibe.branchPrefix feat/
+git -C "${SHELL_REPO_DIR}" config vibe.mode worktree
 git -C "${SHELL_REPO_DIR}" config vibe.worktreeRoot ../.vibe
 EXPECTED_SHELL_REPO_DIR="$(cd "${SHELL_REPO_DIR}" && pwd -P)"
 
@@ -912,5 +1084,35 @@ FINISH_OUTPUT="$(HOME="${INSTALL_HOME}" SHELL=/bin/bash bash -lc '
 ')"
 
 [[ "${FINISH_OUTPUT}" == "${EXPECTED_SHELL_REPO_DIR}" ]] || fail "shell integration did not return to the base worktree after finish"
+
+git -C "${SHELL_REPO_DIR}" config vibe.mode solo
+
+SOLO_AUTO_CD_OUTPUT="$(HOME="${INSTALL_HOME}" SHELL=/bin/bash bash -lc '
+  source ~/.bashrc
+  cd "'"${SHELL_REPO_DIR}"'"
+  git vc shell-solo >/dev/null
+  pwd -P
+')"
+[[ "${SOLO_AUTO_CD_OUTPUT}" == "${EXPECTED_SHELL_REPO_DIR}" ]] || fail "shell integration should stay in the repo root for solo mode"
+[[ "$(git -C "${SHELL_REPO_DIR}" branch --show-current)" == "feat/shell-solo" ]] || fail "git vc did not switch to the solo branch"
+
+SOLO_ENTER_SHELL_OUTPUT="$(HOME="${INSTALL_HOME}" SHELL=/bin/bash bash -lc '
+  source ~/.bashrc
+  cd "'"${SHELL_REPO_DIR}"'"
+  git switch main >/dev/null
+  git vibe enter shell-solo >/dev/null
+  pwd -P
+')"
+[[ "${SOLO_ENTER_SHELL_OUTPUT}" == "${EXPECTED_SHELL_REPO_DIR}" ]] || fail "shell enter should stay in the repo root for solo mode"
+[[ "$(git -C "${SHELL_REPO_DIR}" branch --show-current)" == "feat/shell-solo" ]] || fail "enter did not switch back to the solo branch"
+
+SOLO_FINISH_SHELL_OUTPUT="$(HOME="${INSTALL_HOME}" SHELL=/bin/bash bash -lc '
+  source ~/.bashrc
+  cd "'"${SHELL_REPO_DIR}"'"
+  git vibe finish >/dev/null
+  pwd -P
+')"
+[[ "${SOLO_FINISH_SHELL_OUTPUT}" == "${EXPECTED_SHELL_REPO_DIR}" ]] || fail "shell finish should leave solo mode in the repo root"
+[[ "$(git -C "${SHELL_REPO_DIR}" branch --show-current)" == "main" ]] || fail "finish did not return the solo shell repo to main"
 
 printf 'smoke: shell integration ok\n'


### PR DESCRIPTION
## Summary
- add `vibe.mode` with `solo` and `worktree` behavior plus per-command overrides
- teach `code`, `issue`, `start`, `enter`, `open`, `finish`, `list`, `status`, `check`, and `path` to understand solo-backed vibes
- document the workflow tradeoffs and add smoke coverage for config precedence, solo flows, overrides, and shell integration

Closes #26